### PR TITLE
Remove transition period support for missing sticker set names

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -134,9 +134,9 @@ Agents can be configured with:
 - `sticker_set_names`: List of available sets
 - `explicit_stickers`: Specific set::sticker mappings
 
-**Transition period:**
-- Missing set lines in sticker triggers are temporarily supported
-- Will be removed in future version
+**Current requirements:**
+- Both set name and sticker name are required in sticker triggers
+- Single-line sticker triggers (missing set name) are no longer supported
 
 ## Caching Strategy
 


### PR DESCRIPTION
- Remove allow_missing_set_during_transition parameter from parse_sticker_body()
- Require both set name and sticker name in sticker triggers
- Update documentation to reflect current requirements
- Single-line sticker triggers (missing set name) are no longer supported

Resolves #12
