### PR TITLE
Fix empty conversation issue when marked as unread

### DIFF
--- a/handlers/received.py
+++ b/handlers/received.py
@@ -320,10 +320,10 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
     #     and not any(m.from_id.user_id == agent.agent_id) for m in messages)
     is_conversation_start = True
     for m in messages:
-        logger.info(
-            f"=====> MESSAGE: from {m.from_id.user_id} agent {agent.agent_id} message {m}"
-        )
-        if m.from_id.user_id == agent.agent_id:
+        if (
+            getattr(m, "from_id", None)
+            and getattr(m.from_id, "user_id", None) == agent.agent_id
+        ):
             is_conversation_start = False
             break
 

--- a/handlers/received.py
+++ b/handlers/received.py
@@ -314,15 +314,11 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
 
     # Detect if this is the start of a conversation (only user messages, no agent messages)
     # We need to check this before finalizing the system prompt
-    # is_conversation_start = (
-    #     not messages
-    #     or len(messages) <= 10
-    #     and not any(m.from_id.user_id == agent.agent_id) for m in messages)
     is_conversation_start = True
     for m in messages:
         if (
             getattr(m, "from_id", None)
-            and getattr(m.from_id, "user_id", None) == agent.agent_id
+            and getattr(m.from_id, "user_id", None) == agent_id
         ):
             is_conversation_start = False
             break

--- a/handlers/received.py
+++ b/handlers/received.py
@@ -6,7 +6,6 @@
 import logging
 import re
 import uuid
-from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 
 from telethon.errors.rpcerrorlist import (
@@ -17,9 +16,7 @@ from telethon.tl.functions.messages import SetTypingRequest
 from telethon.tl.types import SendMessageTypingAction
 
 from agent import get_agent_for_id
-from llm import GeminiLLM
 from media_injector import (
-    build_prompt_lines_from_messages,
     format_message_for_prompt,
     inject_media_descriptions,
 )
@@ -81,65 +78,63 @@ def _to_chatmsg_single_text_part(
     }
 
 
-async def query_llm_structured_with_rendered_history(
-    *,
-    llm: GeminiLLM,
-    persona_instructions: str,
-    role_prompt: str | None,
-    llm_specific_prompt: str | None,
-    now_iso: str,
-    chat_type: str,  # "direct" | "group"
-    curated_stickers: Iterable[str] | None,
-    history_rendered_items: list[tuple[str, str, str, str, bool]],
-    target_rendered_item: tuple[str, str, str, str, bool] | None,
-    history_size: int = 500,
-    include_message_ids: bool = True,
-    model: str | None = None,
-    timeout_s: float | None = None,
-) -> str:
+async def _build_sticker_list(agent, media_chain) -> str | None:
     """
-    Thin adapter that maps your existing *rendered* strings into the ChatMsg+parts
-    structure used by the role-based Gemini path. It preserves your current prompt
-    text exactly (one text part per message) so runtime behavior remains unchanged.
+    Build a formatted list of available stickers with descriptions.
+
+    Args:
+        agent: Agent instance with sticker cache
+        media_chain: Media source chain for description lookups
+
+    Returns:
+        Formatted sticker list string or None if no stickers available
     """
-    history_chatmsgs: list[dict] = []
-    for rendered, sender, sender_id, msg_id, is_agent in history_rendered_items:
-        history_chatmsgs.append(
-            _to_chatmsg_single_text_part(
-                rendered=rendered,
-                sender=sender,
-                sender_id=sender_id,
-                msg_id=msg_id,
-                is_agent=is_agent,
-            )
-        )
+    if not agent.sticker_cache_by_set:
+        return None
 
-    target_chatmsg: dict | None = None
-    if target_rendered_item is not None:
-        (tr, ts, tsid, tmid, t_is_agent) = target_rendered_item
-        # target is always treated as a user turn; if t_is_agent is True, we still force user
-        target_chatmsg = _to_chatmsg_single_text_part(
-            rendered=tr,
-            sender=ts,
-            sender_id=tsid,
-            msg_id=tmid,
-            is_agent=False,
-        )
+    lines: list[str] = []
+    try:
+        for set_short, name in sorted(agent.sticker_cache_by_set.keys()):
+            try:
+                if set_short == "AnimatedEmojies":
+                    # Don't describe these - they are just animated emojis
+                    desc = None
+                else:
+                    # Get the document from the sticker cache
+                    doc = agent.sticker_cache_by_set.get((set_short, name))
+                    if doc:
+                        # Get unique_id from document
+                        _uid = get_unique_id(doc)
 
-    return await llm.query_structured(
-        persona_instructions=persona_instructions,
-        role_prompt=role_prompt,
-        llm_specific_prompt=llm_specific_prompt,
-        now_iso=now_iso,
-        chat_type=chat_type,
-        curated_stickers=curated_stickers,
-        history=history_chatmsgs,
-        target_message=target_chatmsg,
-        history_size=history_size,
-        include_message_ids=include_message_ids,
-        model=model,
-        timeout_s=timeout_s,
-    )
+                        # Use agent's media source chain
+                        cache_record = await media_chain.get(
+                            unique_id=_uid,
+                            agent=agent,
+                            doc=doc,
+                            kind="sticker",
+                            sticker_set_name=set_short,
+                            sticker_name=name,
+                        )
+                        desc = cache_record.get("description") if cache_record else None
+                    else:
+                        desc = None
+            except Exception as e:
+                logger.exception(f"Failed to process sticker {set_short}::{name}: {e}")
+                desc = None
+            if desc:
+                lines.append(f"- {set_short} :: {name} - {desc}")
+            else:
+                lines.append(f"- {set_short} :: {name}")
+    except Exception as e:
+        # If anything unexpected occurs, fall back to names-only list
+        logger.warning(
+            f"Failed to build sticker descriptions, falling back to names-only: {e}"
+        )
+        lines = [
+            f"- {s} :: {n}" for (s, n) in sorted(agent.sticker_cache_by_set.keys())
+        ]
+
+    return "\n".join(lines) if lines else None
 
 
 def parse_llm_reply_from_markdown(
@@ -311,57 +306,7 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
     # Build the by-set sticker list, computing descriptions via helper so tests can monkeypatch it.
     # Priority: Stickers already described in messages (step 3) will be cache hits (no budget consumed)
     # Only new stickers not in messages will consume remaining budget
-    sticker_list = None
-    if agent.sticker_cache_by_set:
-        lines: list[str] = []
-        try:
-            for set_short, name in sorted(agent.sticker_cache_by_set.keys()):
-                try:
-                    if set_short == "AnimatedEmojies":
-                        # Don't describe these - they are just animated emojis
-                        desc = None
-                    else:
-                        # Get the document from the sticker cache
-                        doc = agent.sticker_cache_by_set.get((set_short, name))
-                        if doc:
-                            # Get unique_id from document
-                            _uid = get_unique_id(doc)
-
-                            # Use agent's media source chain
-                            cache_record = await media_chain.get(
-                                unique_id=_uid,
-                                agent=agent,
-                                doc=doc,
-                                kind="sticker",
-                                sticker_set_name=set_short,
-                                sticker_name=name,
-                            )
-                            desc = (
-                                cache_record.get("description")
-                                if cache_record
-                                else None
-                            )
-                        else:
-                            desc = None
-                except Exception as e:
-                    logger.exception(
-                        f"Failed to process sticker {set_short}::{name}: {e}"
-                    )
-                    desc = None
-                if desc:
-                    lines.append(f"- {set_short} :: {name} - {desc}")
-                else:
-                    lines.append(f"- {set_short} :: {name}")
-        except Exception as e:
-            # If anything unexpected occurs, fall back to names-only list
-            logger.warning(
-                f"Failed to build sticker descriptions, falling back to names-only: {e}"
-            )
-            lines = [
-                f"- {s} :: {n}" for (s, n) in sorted(agent.sticker_cache_by_set.keys())
-            ]
-
-        sticker_list = "\n".join(lines) if lines else sticker_list
+    sticker_list = await _build_sticker_list(agent, media_chain)
 
     if sticker_list:
         system_prompt += f"\n\n# Stickers you may send\n\n{sticker_list}\n"
@@ -369,17 +314,22 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
 
     # Detect if this is the start of a conversation (only user messages, no agent messages)
     # We need to check this before finalizing the system prompt
-    is_conversation_start = False
-    if messages:
-        # Check if all messages are from users (not from the agent) AND
-        # there are 10 or fewer messages (to avoid false positives from truncated history)
-        is_conversation_start = len(messages) <= 10 and not any(
-            getattr(m, "out", False) for m in messages
+    # is_conversation_start = (
+    #     not messages
+    #     or len(messages) <= 10
+    #     and not any(m.from_id.user_id == agent.agent_id) for m in messages)
+    is_conversation_start = True
+    for m in messages:
+        logger.info(
+            f"=====> MESSAGE: from {m.from_id.user_id} agent {agent.agent_id} message {m}"
         )
+        if m.from_id.user_id == agent.agent_id:
+            is_conversation_start = False
+            break
 
     # Add conversation start instruction if this is the beginning of a conversation
     if is_conversation_start:
-        conversation_start_instruction = f"\n\nThis is the beginning of a conversation with {channel_name}. Please respond with your first message."
+        conversation_start_instruction = f"\n\n***IMPORTANT***\n\nThis is the beginning of a conversation with {channel_name}. Please respond with your first message."
         system_prompt = system_prompt + conversation_start_instruction
         logger.info(
             f"[{agent_name}] Detected conversation start with {channel_name} ({len(messages)} messages), added first message instruction"
@@ -391,14 +341,6 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
         f"\n\n# Chat Type\n\nThis is a {'group' if is_group else 'direct (one-on-one)'} chat.\n"
     )
 
-    # ----- Build rendered history (one text part per message; preserves current behavior) -----
-    # We will still build the "context_lines" string for logging parity, but the LLM call will
-    # use per-message parts instead of one big user_prompt.
-    context_lines = await build_prompt_lines_from_messages(
-        messages, agent=agent, media_chain=media_chain
-    )
-    formatted_context = "\n".join(context_lines)
-
     # Map each Telethon message to a 5-tuple:
     # (rendered_text, sender_display, sender_id, message_id, is_agent)
     history_rendered_items: list[tuple[str, str, str, str, bool]] = []
@@ -407,6 +349,8 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
         rendered_text = await format_message_for_prompt(
             m, agent=agent, media_chain=media_chain
         )
+        if not rendered_text:
+            continue
 
         # sender_id is stable; get display name for better context
         sender_id_val = getattr(m, "sender_id", None)
@@ -429,54 +373,26 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
     message_id_param = task.params.get("message_id", None)
     target_msg = None
     if message_id_param is not None:
-        for m in reversed(messages):  # search newest → oldest
+        for m in messages:
             if getattr(m, "id", None) == message_id_param:
                 target_msg = m
                 break
-    if target_msg is None and messages:
-        target_msg = messages[-1]  # newest
 
-    target_rendered_item: tuple[str, str, str, str, bool] | None = None
-    user_message = None
-    if target_msg is not None:
-        user_message = await format_message_for_prompt(
-            target_msg, agent=agent, media_chain=media_chain
-        )
-        t_sender_id_val = getattr(target_msg, "sender_id", None)
-        t_sender_id = str(t_sender_id_val) if t_sender_id_val is not None else "unknown"
-        t_message_id = str(getattr(target_msg, "id", ""))
+    # Add target message instruction if provided
+    if target_msg is not None and getattr(target_msg, "id", ""):
+        system_prompt += f"\n# Target Message\nConsider responding to message with message_id {getattr(target_msg, "id", "")}.\n"
 
-        # Get actual sender name for target message
-        t_sender_display = (
-            await get_channel_name(agent, t_sender_id_val)
-            if t_sender_id_val
-            else "unknown"
-        )
-
-        # is_agent for target is forced to False (target messages are always from users)
-        target_rendered_item = (
-            user_message,
-            t_sender_display,
-            t_sender_id,
-            t_message_id,
-            False,
-        )
-
-    # ----- Role-structured LLM call (replacing the old llm.query(system_prompt, user_prompt)) -----
     # We keep your existing prompt strings intact, but pass history as parts.
     now_iso = datetime.now(UTC).isoformat(timespec="seconds")
     chat_type = "group" if is_group else "direct"
 
-    # persona_instructions: we use the full system_prompt you've assembled (keeps behavior identical)
+    # system_prompt: we use the full system_prompt you've assembled (keeps behavior identical)
     # role_prompt and llm_specific_prompt are passed as None because they are already included in system_prompt.
     try:
         reply = await llm.query_structured(
-            persona_instructions=system_prompt,
-            role_prompt=None,
-            llm_specific_prompt=None,
+            system_prompt=system_prompt,
             now_iso=now_iso,
             chat_type=chat_type,
-            curated_stickers=None,  # already embedded into persona_instructions above
             history=(
                 {
                     "sender": s,
@@ -487,20 +403,7 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
                 }
                 for (rendered, s, sid, mid, is_self) in history_rendered_items
             ),
-            target_message=(
-                {
-                    "sender": target_rendered_item[1],
-                    "sender_id": target_rendered_item[2],
-                    "msg_id": target_rendered_item[3],
-                    "is_agent": False,
-                    "parts": [{"kind": "text", "text": target_rendered_item[0]}],
-                }
-                if target_rendered_item is not None
-                else None
-            ),
             history_size=agent.llm.history_size,
-            include_message_ids=True,
-            model=None,
             timeout_s=None,
         )
     except Exception as e:
@@ -541,15 +444,8 @@ async def handle_received(task: TaskNode, graph: TaskGraph):
             logger.error(f"[{agent_name}] LLM permanent failure: {e}")
             return
 
-    logger.debug(
-        f"[{agent_name}] LLM prompt (for debugging):\n"
-        f"System turn text length: {len(system_prompt)}\n"
-        f"History messages: {len(history_rendered_items)}\n"
-        f"Context preview:\n{formatted_context[-1000:]}"  # last 1000 chars to keep logs tidy
-    )
-
     if reply == "":
-        logger.info(f"[{agent_name}] LLM decided not to reply to {user_message}")
+        logger.info(f"[{agent_name}] LLM decided not to reply to {message_id_param}")
         return
 
     logger.debug(f"[{agent_name}] LLM reply: {reply}")

--- a/llm/base.py
+++ b/llm/base.py
@@ -84,4 +84,4 @@ class LLM(ABC):
         Structured query method for conversation-aware LLMs.
         Default implementation falls back to basic query method.
         """
-        pass
+        ...

--- a/llm/base.py
+++ b/llm/base.py
@@ -68,25 +68,15 @@ class LLM(ABC):
     prompt_name: str = "Default"
 
     @abstractmethod
-    async def query(self, system_prompt: str, user_prompt: str) -> str:
-        """
-        Basic query method for simple system + user prompt.
-        """
-        pass
-
     async def query_structured(
         self,
         *,
-        persona_instructions: str,
-        role_prompt: str | None,
-        llm_specific_prompt: str | None,
+        system_prompt: str,
         now_iso: str,
         chat_type: str,  # "direct" | "group"
         curated_stickers: Iterable[str] | None,
         history: Iterable[ChatMsg],
-        target_message: ChatMsg | None,
         history_size: int = 500,
-        include_message_ids: bool = True,
         model: str | None = None,
         timeout_s: float | None = None,
     ) -> str:
@@ -94,29 +84,4 @@ class LLM(ABC):
         Structured query method for conversation-aware LLMs.
         Default implementation falls back to basic query method.
         """
-        # Default implementation: fallback to basic query
-        # Subclasses can override this for more sophisticated handling
-        system_prompt = persona_instructions
-        if role_prompt:
-            system_prompt += f"\n\n{role_prompt}"
-        if llm_specific_prompt:
-            system_prompt += f"\n\n{llm_specific_prompt}"
-
-        # Simple conversion of history to text
-        user_prompt = f"Current time: {now_iso}\nChat type: {chat_type}\n\n"
-        if target_message:
-            # Extract text from parts if available, otherwise fall back to text field
-            message_text = ""
-            parts = target_message.get("parts")
-            if parts:
-                # Extract text from all text parts
-                text_parts = []
-                for part in parts:
-                    if part.get("kind") == "text" and part.get("text"):
-                        text_parts.append(part["text"])
-                message_text = " ".join(text_parts)
-            else:
-                message_text = target_message.get("text", "")
-            user_prompt += f"Latest message: {message_text}"
-
-        return await self.query(system_prompt, user_prompt)
+        pass

--- a/llm/chatgpt.py
+++ b/llm/chatgpt.py
@@ -31,20 +31,3 @@ class ChatGPT(LLM):
         self.model = model
         self.temperature = temperature
         self.history_size = 120
-
-    async def query(self, system_prompt: str, user_prompt: str) -> str:
-        logger.debug(f"Querying ChatGPT with '{system_prompt}' and '{user_prompt}'")
-        response = await self.client.chat.completions.create(
-            model=self.model,
-            temperature=self.temperature,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            n=1,
-        )
-
-        if not response.choices:
-            raise RuntimeError("LLM returned no choices.")
-
-        return response.choices[0].message.content.strip()

--- a/llm/gemini.py
+++ b/llm/gemini.py
@@ -394,6 +394,18 @@ class GeminiLLM(LLM):
             bool(system_instruction),
         )
 
+        # Ensure we have at least one user turn for Gemini's requirements
+        # Only add special user turn if we have no conversation history at all
+        if not contents_for_call or not any(
+            turn.get("role") == "user" for turn in contents_for_call
+        ):
+            # Add a special user turn if we don't have any user turns
+            # This indicates the start of a new conversation
+            special_user_message = "[special] This is the start of a new conversation. The user has noticed that you are a contact."
+            contents_for_call = [
+                {"role": "user", "parts": [{"text": special_user_message}]}
+            ]
+
         return await self._generate_with_contents(
             contents=contents_for_call,
             model=model,

--- a/llm/ollama.py
+++ b/llm/ollama.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Cindy's World LLC and contributors
 # Licensed under the MIT License. See LICENSE.md for details.
 
-import httpx
 
 from .base import LLM
 
@@ -14,20 +13,3 @@ class OllamaLLM(LLM):
         self.base_url = base_url.rstrip("/")
         self.model = model
         self.history_size = 5
-
-    async def query(self, system: str, user: str) -> str:
-        url = f"{self.base_url}/api/chat"
-        payload = {
-            "model": self.model,
-            "messages": [
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
-            ],
-            "stream": False,
-        }
-
-        async with httpx.AsyncClient() as client:
-            response = await client.post(url, json=payload, timeout=60)
-            response.raise_for_status()
-            data = response.json()
-        return data.get("message", {}).get("content", "")

--- a/llm/prompt_builder.py
+++ b/llm/prompt_builder.py
@@ -94,7 +94,6 @@ def build_gemini_contents(
     any_user_messages = False
     any_agent_messages = False
     for m in history:
-        logger.info(f"=====> HISTORY ITEM: {m}")
         is_agent = bool(m.get("is_agent"))
         any_user_messages = any_user_messages or not is_agent
         any_agent_messages = any_agent_messages or is_agent
@@ -111,7 +110,7 @@ def build_gemini_contents(
         if any_agent_messages:
             special_user_message = "[special] The user has not responded yet."
         else:
-            special_user_message = "[special] This is the beginning of a conversation with Michael Duboy. Please respond with your first message."
+            special_user_message = "[special] This is the beginning of a conversation. Please respond with your first message."
         contents.append(
             {"role": "user", "parts": [_mk_text_part(special_user_message)]}
         )

--- a/llm/prompt_builder.py
+++ b/llm/prompt_builder.py
@@ -3,10 +3,13 @@
 # Copyright (c) 2025 Cindy's World LLC and contributors
 # Licensed under the MIT License. See LICENSE.md for details.
 
+import logging
 from collections.abc import Iterable
 from typing import Any
 
 from .base import ChatMsg, MsgPart
+
+logger = logging.getLogger(__name__)
 
 
 def _mk_text_part(text: str) -> dict[str, str]:
@@ -16,7 +19,6 @@ def _mk_text_part(text: str) -> dict[str, str]:
 def _normalize_parts_for_message(
     m: ChatMsg,
     *,
-    include_message_ids: bool,
     is_agent: bool,
 ) -> list[dict[str, str]]:
     """
@@ -37,7 +39,7 @@ def _normalize_parts_for_message(
             header_bits.append(f'sender="{who}" sender_id={sid}')
         elif who or sid:
             header_bits.append(f"sender_id={who or sid}")
-        if include_message_ids and m.get("msg_id"):
+        if m.get("msg_id"):
             header_bits.append(f'message_id={m["msg_id"]}')
         if header_bits:
             parts.append(_mk_text_part(f"[metadata] {' '.join(header_bits)}"))
@@ -75,24 +77,10 @@ def _normalize_parts_for_message(
 
 
 def build_gemini_contents(
-    *,
-    # System turn inputs
-    persona_instructions: str,
-    role_prompt: str | None,
-    llm_specific_prompt: str | None,
-    now_iso: str,
-    chat_type: str,  # "direct" | "group" (stringly typed to avoid import cycles)
-    curated_stickers: Iterable[str] | None = None,
-    # History & target
     history: Iterable[ChatMsg],
-    target_message: ChatMsg | None,  # message we want the model to respond to
-    history_size: int = 500,
-    # Formatting toggles
-    include_message_ids: bool = True,
 ) -> list[dict[str, Any]]:
     """
     Construct Gemini 'contents' with roles and multi-part messages:
-      - One 'system' turn: persona + role prompt + model-specific prompt + metadata + target instruction
       - Chronological 'user'/'assistant' turns for prior messages (bounded by history_size),
         each with an ordered list of 'parts' (metadata header first, then content parts).
       - Target message is NOT appended as a separate turn; instead, a system instruction
@@ -100,44 +88,32 @@ def build_gemini_contents(
 
     Pure function: no I/O, no network, no mutation of inputs.
     """
-    # --- 1) System turn ---
-    sys_lines: list[str] = []
-    if persona_instructions:
-        sys_lines.append(persona_instructions.strip())
-    if role_prompt:
-        sys_lines.append("\n# Role Prompt\n" + role_prompt.strip())
-    if llm_specific_prompt:
-        sys_lines.append("\n# Model-Specific Guidance\n" + llm_specific_prompt.strip())
-    sys_lines.append(f"\n# Context\nCurrent time: {now_iso}\nChat type: {chat_type}")
-    if curated_stickers:
-        sticker_list = ", ".join(curated_stickers)
-        sys_lines.append(f"Curated stickers available: {sticker_list}")
-
-    # Add target message instruction if provided
-    if target_message is not None and target_message.get("msg_id"):
-        sys_lines.append(
-            f"\n# Target Message\nConsider responding to message with message_id {target_message['msg_id']}."
-        )
-
-    contents: list[dict[str, Any]] = [
-        {"role": "system", "parts": [_mk_text_part("\n\n".join(sys_lines).strip())]}
-    ]
 
     # --- 2) Chronological history (bounded) ---
-    hist_list = list(history)
-    if history_size >= 0:
-        hist_list = hist_list[-history_size:]
-
-    for m in hist_list:
+    contents = []
+    any_user_messages = False
+    any_agent_messages = False
+    for m in history:
+        logger.info(f"=====> HISTORY ITEM: {m}")
         is_agent = bool(m.get("is_agent"))
+        any_user_messages = any_user_messages or not is_agent
+        any_agent_messages = any_agent_messages or is_agent
         role = "assistant" if is_agent else "user"
         parts = _normalize_parts_for_message(
             m,
-            include_message_ids=include_message_ids,
             is_agent=is_agent,
         )
         if parts:
             contents.append({"role": role, "parts": parts})
 
-    # Note: Target message is no longer appended as a separate turn
+    # Ensure we have at least one user turn for Gemini's requirements
+    if not any_user_messages:
+        if any_agent_messages:
+            special_user_message = "[special] The user has not responded yet."
+        else:
+            special_user_message = "[special] This is the beginning of a conversation with Michael Duboy. Please respond with your first message."
+        contents.append(
+            {"role": "user", "parts": [_mk_text_part(special_user_message)]}
+        )
+
     return contents

--- a/media_injector.py
+++ b/media_injector.py
@@ -306,30 +306,5 @@ async def format_message_for_prompt(msg: Any, *, agent, media_chain=None) -> str
             desc_text = meta.get("description") if isinstance(meta, dict) else None
             parts.append(format_media_sentence(it.kind, desc_text))
 
-    content = " ".join(parts) if parts else "[no content]"
+    content = " ".join(parts) if parts else None
     return content
-
-
-async def build_prompt_lines_from_messages(
-    messages: list[Any], *, agent, media_chain=None
-) -> list[str]:
-    """
-    Convert Telethon messages into the list of prompt lines for logging.
-      - Iterate messages in chronological order (oldest → newest)
-      - For each message, consult the media cache populated by inject_media_descriptions
-      - Produce string lines (stickers/photos/gifs substituted with descriptions)
-      - Do NOT download or call the LLM here; cache-only
-      - Note: This is used for logging only; the actual LLM uses structured format
-
-    Args:
-        messages: List of Telethon messages
-        agent: Agent instance
-        media_chain: Media source chain to use for description lookups
-    """
-    lines = []
-    for msg in reversed(messages):
-        content = await format_message_for_prompt(
-            msg, agent=agent, media_chain=media_chain
-        )
-        lines.append(content)
-    return lines

--- a/media_injector.py
+++ b/media_injector.py
@@ -22,20 +22,6 @@ from telegram_util import get_channel_name  # for sender/channel names
 
 logger = logging.getLogger(__name__)
 
-# Feature flags
-# Constants moved to media_budget.py to avoid circular imports
-MEDIA_FEATURE_ENABLED = True  # you've been keeping this True for manual testing
-
-# debug_save_media moved to media_budget.py to avoid circular imports
-
-
-# --- Per-tick AI description budget ------------------------------------------
-
-# Budget functions moved to media_budget.py to avoid circular imports
-
-
-# ---------- format sniffing & support checks ----------
-
 
 # ---------- sticker helpers ----------
 async def _maybe_get_sticker_set_short_name(agent, it) -> str | None:
@@ -138,8 +124,6 @@ async def _resolve_sender_and_channel(
 
 # ---------- main ----------
 
-# get_or_compute_description_for_doc removed - replaced by AIGeneratingMediaSource
-
 
 async def inject_media_descriptions(
     messages: Sequence[Any], agent: Any | None = None, peer_id: int | None = None
@@ -157,7 +141,7 @@ async def inject_media_descriptions(
 
     Returns the messages unchanged. Prompt creation happens where the cache is read.
     """
-    if not MEDIA_FEATURE_ENABLED or agent is None:
+    if not agent:
         return messages
 
     # Get the agent's media source chain

--- a/run.py
+++ b/run.py
@@ -64,17 +64,15 @@ async def handle_incoming_message(agent: Agent, work_queue, event):
     # Format message content for logging
     message_content = format_message_content_for_logging(event.message)
 
-    if sender_name == dialog_name:
-        logger.info(
-            f"[{agent_name}] Message from [{sender_name}]: {message_content!r} (callout: {is_callout})"
-        )
-    else:
-        logger.info(
-            f"[{agent_name}] Message from [{sender_name}] in [{dialog_name}]: {message_content!r} (callout: {is_callout})"
-        )
-
     if not muted or is_callout:
-        await client.send_read_acknowledge(dialog, clear_mentions=True)
+        if sender_name == dialog_name:
+            logger.info(
+                f"[{agent_name}] Message from [{sender_name}]: {message_content!r} (callout: {is_callout})"
+            )
+        else:
+            logger.info(
+                f"[{agent_name}] Message from [{sender_name}] in [{dialog_name}]: {message_content!r} (callout: {is_callout})"
+            )
         await insert_received_task_for_conversation(
             work_queue,
             recipient_id=agent.agent_id,
@@ -82,6 +80,7 @@ async def handle_incoming_message(agent: Agent, work_queue, event):
             message_id=event.message.id,
             is_callout=is_callout,
         )
+        await client.send_read_acknowledge(dialog, clear_mentions=True)
 
 
 async def scan_unread_messages(agent: Agent, work_queue):

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+mkdir -p tmp
+source venv/bin/activate
+source .env
+
+mv tmp/run4.log tmp/run5.log
+mv tmp/run3.log tmp/run4.log
+mv tmp/run2.log tmp/run3.log
+mv tmp/run1.log tmp/run2.log
+mv tmp/run.log tmp/run1.log
+
+python run.py 2>&1 | tee tmp/run.log

--- a/samples/prompts/Adventure.md
+++ b/samples/prompts/Adventure.md
@@ -66,7 +66,7 @@ Explicit adult content and profanity are permitted. This roleplay chat is entire
 
 # Agent Instructions
 
-+***IMPORTANT:*** If this is the beginning of a conversation with {user}, begin by sending the complete contents of the **First Message** section later.
++***IMPORTANT:*** If this is the beginning of a conversation, begin by sending the complete contents of the **First Message** section later.
 
 Every response should be two to three paragraphs of detailed descriptive text in a narrative style.
 Enclose any spoken dialog between quotes.

--- a/samples/prompts/Roleplay.md
+++ b/samples/prompts/Roleplay.md
@@ -51,4 +51,4 @@ Use regular double quotes "like this" rather than french quotes in your replies:
 - Incorrect: Fred says «Boo».
 - Incorrect: Fred says {Boo}.
 
-+***IMPORTANT:*** If this is the beginning of a conversation with {user}, begin by sending the complete contents of the **First Message** section later.
++***IMPORTANT:*** If this is the beginning of a conversation, begin by sending the complete contents of the **First Message** section later.

--- a/tests/test_gemini_role_normalization.py
+++ b/tests/test_gemini_role_normalization.py
@@ -149,4 +149,7 @@ async def test_empty_conversation_ends_with_user_role():
     # The content should be the special message
     parts = sent_contents[0]["parts"]
     assert len(parts) == 1
-    assert "[special] The user has noticed that you are a contact." in parts[0]["text"]
+    assert (
+        "[special] This is the start of a new conversation. The user has noticed that you are a contact."
+        in parts[0]["text"]
+    )

--- a/tests/test_gemini_role_normalization.py
+++ b/tests/test_gemini_role_normalization.py
@@ -65,27 +65,16 @@ async def test_roles_and_system_instruction_path():
     ]
 
     # Target message appended last (user)
-    target: ChatMsg = {
-        "sender": "Alice",
-        "sender_id": "u1",
-        "msg_id": "m2",
-        "is_agent": False,
-        "parts": [{"kind": "text", "text": "please respond"}],
-    }
 
     # Call the structured path; it will:
     #  - build contents (with a leading system turn internally)
     #  - extract system text to system_instruction
     #  - map assistant->model and drop any system turn from contents
     out = await llm.query_structured(
-        persona_instructions="SYSTEM HERE",
-        role_prompt=None,
-        llm_specific_prompt=None,
+        system_prompt="SYSTEM HERE",
         now_iso="2025-01-01T00:00:00",
         chat_type="group",
-        curated_stickers=None,
         history=history,
-        target_message=target,
     )
 
     assert out == "ok"
@@ -117,18 +106,13 @@ async def test_empty_conversation_ends_with_user_role():
 
     # Empty history (no messages) and no target message
     history: list[ChatMsg] = []
-    target: ChatMsg | None = None
 
     # Call the structured path with empty history and no target
     out = await llm.query_structured(
-        persona_instructions="SYSTEM HERE",
-        role_prompt=None,
-        llm_specific_prompt=None,
+        system_prompt="SYSTEM HERE",
         now_iso="2025-01-01T00:00:00",
         chat_type="direct",
-        curated_stickers=None,
         history=history,
-        target_message=target,
     )
 
     assert out == "ok"
@@ -149,7 +133,4 @@ async def test_empty_conversation_ends_with_user_role():
     # The content should be the special message
     parts = sent_contents[0]["parts"]
     assert len(parts) == 1
-    assert (
-        "[special] This is the start of a new conversation. The user has noticed that you are a contact."
-        in parts[0]["text"]
-    )
+    assert "[special] This is the beginning of a conversation" in parts[0]["text"]


### PR DESCRIPTION
- Add special user turn for empty conversations in build_gemini_contents
- Ensures Gemini API requirement that single turn requests end with user role
- Fixes error: 'Please ensure that single turn requests end with a user role'
- Add comprehensive test to verify empty conversation handling
- Maintains backward compatibility with existing functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates to a simplified LLM structured API using system_prompt, updates prompt building and handlers (including sticker list and conversation start logic), and adds tests to ensure empty conversations end with a user turn.
> 
> - **LLM/Core**:
>   - Simplify `LLM.query_structured` to accept `system_prompt` and drop `target_message`, `include_message_ids`, and curated stickers; remove legacy `query` paths across implementations.
>   - `GeminiLLM`: build contents from history only, pass `system_prompt` via `system_instruction`, normalize roles, and retry handling preserved.
> - **Prompt Builder**:
>   - `build_gemini_contents(history)`: remove system/role/target assembly; ensure at least one user turn by injecting a special user message for empty conversations.
>   - Message normalization always includes `message_id` in non-agent metadata; placeholders for unrendered media preserved.
> - **Handlers** (`handlers/received.py`):
>   - Add `_build_sticker_list` helper using media source cache; skip `AnimatedEmojies` descriptions.
>   - More robust conversation-start detection (checks for agent `from_id`); add explicit target-message hint in `system_prompt`.
>   - Skip empty rendered messages; update querying to new `query_structured` signature.
> - **Media**:
>   - `format_message_for_prompt` returns `None` when no content; minor fallback adjustments.
> - **Runtime**:
>   - `run.py`: tweak logging/acknowledge order; mark-unread handling unchanged; add `run.sh` helper.
> - **Prompts**:
>   - Clarify “beginning of a conversation” instruction in `samples/prompts/*`.
> - **Tests**:
>   - Update tests for new API and builder; add test ensuring empty conversations end with a user role.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7812b9dc2d65b989da0bc68b592be1cb90ef4ccf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->