### PR TITLE
Implement typing indicators with proportional delays

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,8 +25,8 @@ This is required by newer Gemini families (e.g., `gemini-2.5-flash-preview-09-20
 ### History ordering and target message
 
 - History is chronological (oldest → newest), capped by `history_size` (default 500 messages).
-- The **target message** (the one we want a response to) is NOT appended as a separate turn.
-  - Instead, a system instruction is added: "Consider responding to message with message_id NNNN."
+- The **target message** (the one we want a response to)...
+  - Causes a system instruction to be added: "Consider responding to message with message_id NNNN."
   - In DMs, the target is the last message.
   - In groups, the target may be an earlier message (e.g., a reply to something above).
 

--- a/run.py
+++ b/run.py
@@ -246,7 +246,7 @@ async def main():
     agents_list = all_agents()
 
     tick_task = asyncio.create_task(
-        run_tick_loop(work_queue, tick_interval_sec=10, state_file_path=STATE_PATH)
+        run_tick_loop(work_queue, tick_interval_sec=2, state_file_path=STATE_PATH)
     )
 
     telegram_tasks = [
@@ -255,7 +255,7 @@ async def main():
     ]
 
     scan_task = asyncio.create_task(
-        periodic_scan(work_queue, agents_list, interval_sec=90)
+        periodic_scan(work_queue, agents_list, interval_sec=10)
     )
 
     done, pending = await asyncio.wait(

--- a/run.sh
+++ b/run.sh
@@ -4,10 +4,14 @@ mkdir -p tmp
 source venv/bin/activate
 source .env
 
+find . -name "*.pyc" -delete
+find . -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
+
 mv tmp/run4.log tmp/run5.log
 mv tmp/run3.log tmp/run4.log
 mv tmp/run2.log tmp/run3.log
 mv tmp/run1.log tmp/run2.log
 mv tmp/run.log tmp/run1.log
 
+# export GEMINI_DEBUG_LOGGING=true
 PYTHONPATH=src python run.py 2>&1 | tee tmp/run.log

--- a/samples/prompts/Gemini.md
+++ b/samples/prompts/Gemini.md
@@ -27,7 +27,7 @@ This is correct.
 
 # «send»
 
-It contains two messages to send
+It contains two paragraphs to send
 ```
 
 Each task begins with a level 1 heading like `# «send»` or `# «sticker»`,
@@ -36,7 +36,7 @@ You may include as many tasks as you like, and they will be executed in order.
 
 Valid task types:
 
-- `# «send»` — send a text message
+- `# «send»` — send a text message, typically one paragraph
 - `# «sticker»` — send a sticker by sticker set and sticker name
 - `# «wait»` — wait for a specified number of seconds
 - `# «block»` — block the conversation, preventing either participant from sending a message
@@ -46,7 +46,8 @@ Each task type is followed by a body that depends on the type:
 
 ## send
 
-Use this to send a text message. You may include formatting and multiple paragraphs.
+Use this to send a text message.
+Send each paragraph in a separate `# «send»` block.
 
 ```markdown
 # «send»
@@ -61,6 +62,8 @@ by specifying the message number (which appears at the beginning of each line of
 # «send» 1234
 
 Hi Neal, thanks for the update.
+
+# «send»
 
 I'll give you my status later this afternoon.
 ```

--- a/src/task_graph.py
+++ b/src/task_graph.py
@@ -23,7 +23,7 @@ class TaskNode:
     depends_on: list[str] = field(default_factory=list)
     status: str = "pending"
 
-    def is_ready(self, completed_ids: set, now: datetime) -> bool:
+    def is_unblocked(self, completed_ids: set) -> bool:
         if self.status != "pending":
             logger.debug(
                 f"Task {self.identifier} is not pending (status: {self.status})."
@@ -33,6 +33,11 @@ class TaskNode:
             logger.debug(
                 f"Task {self.identifier} dependencies not met: {self.depends_on} vs {completed_ids}."
             )
+            return False
+        return True
+
+    def is_ready(self, completed_ids: set, now: datetime) -> bool:
+        if not self.is_unblocked(completed_ids):
             return False
         if self.type == "wait":
             until = self.params.get("until")


### PR DESCRIPTION
- Add wait tasks before send/sticker tasks with typing=True attribute
- Trigger typing indicators every 2 seconds during wait periods
- Instruct the LLM to place each paragraph in a separate task

Fixes #26 
Fixes #27
Fixes #63 
