### PR TITLE
Fix authentication handling for background server

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -215,7 +215,7 @@ async def run_telegram_loop(agent: Agent, work_queue):
                     logger.error(
                         f"[{agent_name}] Exiting due to authentication failure."
                     )
-                    return  # Exit this agent's loop instead of retrying
+                    break  # Exit the while loop instead of retrying
 
                 await ensure_sticker_cache(agent, client)
                 me = await client.get_me()

--- a/src/run.py
+++ b/src/run.py
@@ -204,6 +204,19 @@ async def run_telegram_loop(agent: Agent, work_queue):
 
         try:
             async with client:
+                # Check if the client is authenticated before proceeding
+                if not await client.is_user_authorized():
+                    logger.error(
+                        f"[{agent_name}] Agent '{agent_name}' is not authenticated to Telegram."
+                    )
+                    logger.error(
+                        f"[{agent_name}] Please run './telegram_login.sh' to authenticate this agent."
+                    )
+                    logger.error(
+                        f"[{agent_name}] Exiting due to authentication failure."
+                    )
+                    return  # Exit this agent's loop instead of retrying
+
                 await ensure_sticker_cache(agent, client)
                 me = await client.get_me()
                 agent_id = me.id


### PR DESCRIPTION
- Add authentication check in run_telegram_loop before using Telegram client
- Exit gracefully with clear error message when agent is not authenticated
- Instruct user to run './telegram_login.sh' instead of retrying indefinitely
- Prevents background server from hanging on authentication failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Telegram authentication checks to background loop and sticker import with clear failure handling; set Flask template folder for media editor.
> 
> - **Backend/Runner (`src/run.py`)**:
>   - Check `client.is_user_authorized()` before startup; log instructions and exit loop on failure instead of retrying.
> - **Media Editor (`src/media_editor.py`)**:
>   - Initialize Flask with `template_folder` pointing to `templates/`.
>   - In `_import_sticker_set_async`, obtain `client` and verify `client.is_user_authorized()`; return structured error with instruction to run `./telegram_login.sh` when unauthenticated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 130f3922c9945dce516eb71c9169764afb35692c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->