### PR TITLE
Limit media display width to 50% of frame width

### DIFF
--- a/templates/media_editor.html
+++ b/templates/media_editor.html
@@ -90,14 +90,14 @@
         }
         .media-preview img {
             max-width: 50%;
-            max-height: 300px;
+            max-height: none;
             width: auto;
             height: auto;
             display: block;
         }
         .media-preview video {
             max-width: 50%;
-            max-height: 300px;
+            max-height: none;
             object-fit: contain;
         }
         .media-info {
@@ -268,7 +268,7 @@
             if (mediaUrl) {
                 if (isAnimated) {
                     // Enhanced video controls for animated content
-                    mediaElement = `<video controls preload="metadata" style="max-width: 50%; max-height: 300px;">
+                    mediaElement = `<video controls preload="metadata" style="max-width: 50%; max-height: 100%;">
                         <source src="${mediaUrl}" type="video/mp4">
                         <source src="${mediaUrl}" type="video/webm">
                         Your browser does not support the video tag.

--- a/templates/media_editor.html
+++ b/templates/media_editor.html
@@ -89,14 +89,14 @@
             padding: 10px;
         }
         .media-preview img {
-            max-width: none;
-            max-height: none;
+            max-width: 50%;
+            max-height: 300px;
             width: auto;
             height: auto;
             display: block;
         }
         .media-preview video {
-            max-width: 300px;
+            max-width: 50%;
             max-height: 300px;
             object-fit: contain;
         }
@@ -268,7 +268,7 @@
             if (mediaUrl) {
                 if (isAnimated) {
                     // Enhanced video controls for animated content
-                    mediaElement = `<video controls preload="metadata" style="max-width: 100%; max-height: 100%;">
+                    mediaElement = `<video controls preload="metadata" style="max-width: 50%; max-height: 300px;">
                         <source src="${mediaUrl}" type="video/mp4">
                         <source src="${mediaUrl}" type="video/webm">
                         Your browser does not support the video tag.


### PR DESCRIPTION
- Updated CSS for images and videos to use max-width: 50%
- Preserves aspect ratio with width: auto and height: auto
- Maintains original width when media is smaller than 50% of frame
- Applied consistently across all media types (images, videos, animated content)
