### PR TITLE
Fix launcher scripts to properly source .env file

### DIFF
--- a/scripts/media_editor.sh
+++ b/scripts/media_editor.sh
@@ -33,6 +33,9 @@ startup_command() {
 
     cd "$PROJECT_ROOT"
     source "$VENV_PATH/bin/activate"
+    if [ -f "$ENV_FILE" ]; then
+        source "$ENV_FILE"
+    fi
     if [ -n "$PYTHONPATH" ]; then
         export PYTHONPATH="$PROJECT_ROOT/src:$PYTHONPATH"
     else

--- a/scripts/media_editor.sh
+++ b/scripts/media_editor.sh
@@ -32,15 +32,6 @@ startup_command() {
     log_info "Host: $host"
 
     cd "$PROJECT_ROOT"
-    source "$VENV_PATH/bin/activate"
-    if [ -f "$ENV_FILE" ]; then
-        source "$ENV_FILE"
-    fi
-    if [ -n "$PYTHONPATH" ]; then
-        export PYTHONPATH="$PROJECT_ROOT/src:$PYTHONPATH"
-    else
-        export PYTHONPATH="$PROJECT_ROOT/src"
-    fi
 
     python "$MAIN_SCRIPT" \
         --port "$port" \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -24,15 +24,6 @@ LOG_FILE="$LOG_DIR/run.log"
 # Startup command: run the agent server
 startup_command() {
     cd "$PROJECT_ROOT"
-    source "$VENV_PATH/bin/activate"
-    if [ -f "$ENV_FILE" ]; then
-        source "$ENV_FILE"
-    fi
-    if [ -n "$PYTHONPATH" ]; then
-        export PYTHONPATH="$PROJECT_ROOT/src:$PYTHONPATH"
-    else
-        export PYTHONPATH="$PROJECT_ROOT/src"
-    fi
 
     python "$MAIN_SCRIPT" \
         < /dev/null \

--- a/src/telegram_login.py
+++ b/src/telegram_login.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 async def login_agent(agent):
     client = get_telegram_client(agent.name, agent.phone)
+    await client.connect()
 
     if await client.is_user_authorized():
         logger.info(f"[{agent.name}] Already logged in.")

--- a/telegram_login.sh
+++ b/telegram_login.sh
@@ -7,25 +7,16 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR"
 VENV_PATH="$PROJECT_ROOT/venv"
+ENV_FILE="$PROJECT_ROOT/.env"
+
+# Source the shared library
+source "$SCRIPT_DIR/scripts/lib.sh"
 
 # Check if virtual environment exists
-if [ ! -d "$VENV_PATH" ]; then
-    echo "Error: Virtual environment not found at $VENV_PATH"
-    echo "Please create it with: python3.13 -m venv venv"
-    exit 1
-fi
+check_venv
 
-# Activate virtual environment and run the script
-cd "$PROJECT_ROOT"
-source "$VENV_PATH/bin/activate"
-if [ -f "$PROJECT_ROOT/.env" ]; then
-    source "$PROJECT_ROOT/.env"
-fi
-if [ -n "$PYTHONPATH" ]; then
-    export PYTHONPATH="$PROJECT_ROOT/src:$PYTHONPATH"
-else
-    export PYTHONPATH="$PROJECT_ROOT/src"
-fi
+# Set up environment using shared function
+setup_environment
 
 # Run telegram_login.py with all arguments
 python "$PROJECT_ROOT/src/telegram_login.py" "$@"

--- a/telegram_login.sh
+++ b/telegram_login.sh
@@ -18,6 +18,9 @@ fi
 # Activate virtual environment and run the script
 cd "$PROJECT_ROOT"
 source "$VENV_PATH/bin/activate"
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    source "$PROJECT_ROOT/.env"
+fi
 if [ -n "$PYTHONPATH" ]; then
     export PYTHONPATH="$PROJECT_ROOT/src:$PYTHONPATH"
 else


### PR DESCRIPTION
- Add .env file sourcing to media_editor.sh startup command
- Add .env file sourcing to telegram_login.sh
- Ensures proper environment variable expansion for all launcher scripts
- Fixes configuration directory issues when using launcher scripts

All three launcher scripts now consistently source both:
1. Virtual environment (venv/bin/activate)
2. Environment file (.env) for shell variable expansion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors launcher scripts to use shared lib for env setup and updates Telegram login to explicitly connect before auth.
> 
> - **Shell scripts**:
>   - `scripts/media_editor.sh` and `scripts/run.sh`: remove inline venv/PYTHONPATH and `.env` sourcing from `startup_command` (handled by shared library).
>   - `telegram_login.sh`: introduce `ENV_FILE`, source `scripts/lib.sh`, and use `check_venv`/`setup_environment` instead of manual setup.
> - **Python**:
>   - `src/telegram_login.py`: add `await client.connect()` before authorization check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c45a1ec47a3d8145abae786ee91c0a657eb03779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->