### PR TITLE
Add basic video support for media editor and fix sticker resolution bugs

### DIFF
--- a/src/llm/gemini.py
+++ b/src/llm/gemini.py
@@ -26,6 +26,12 @@ from .prompt_builder import build_gemini_contents
 
 logger = logging.getLogger(__name__)
 
+GEMINI_DEBUG_LOGGING = os.getenv("GEMINI_DEBUG_LOGGING", "").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+
 
 class GeminiLLM(LLM):
     prompt_name = "Gemini"
@@ -232,7 +238,7 @@ class GeminiLLM(LLM):
                 contents_norm = contents
 
             # Optional comprehensive logging for debugging
-            if os.getenv("GEMINI_DEBUG_LOGGING", "").lower() in ("true", "1", "yes"):
+            if GEMINI_DEBUG_LOGGING:
                 logger.info("=== GEMINI_DEBUG_LOGGING: COMPLETE PROMPT ===")
                 logger.info(f"System Instruction: {system_instruction}")
                 logger.info(f"Contents ({len(contents_norm)} turns):")
@@ -269,15 +275,12 @@ class GeminiLLM(LLM):
                 )
 
                 # Optional comprehensive logging for debugging
-                if os.getenv("GEMINI_DEBUG_LOGGING", "").lower() in (
-                    "true",
-                    "1",
-                    "yes",
-                ):
+                if GEMINI_DEBUG_LOGGING:
                     logger.info("=== GEMINI_DEBUG_LOGGING: COMPLETE RESPONSE ===")
-                    logger.info(f"Response text: {text}")
                     if response is not None:
                         logger.info(f"Response object type: {type(response)}")
+                        if hasattr(response, "text") and isinstance(response.text, str):
+                            logger.info(f"Response text: {response.text}")
                         if hasattr(response, "candidates") and response.candidates:
                             logger.info(
                                 f"Number of candidates: {len(response.candidates)}"

--- a/src/llm/gemini.py
+++ b/src/llm/gemini.py
@@ -233,7 +233,7 @@ class GeminiLLM(LLM):
 
             # Optional comprehensive logging for debugging
             if os.getenv("GEMINI_DEBUG_LOGGING", "").lower() in ("true", "1", "yes"):
-                logger.info("=== GEMINI DEBUG: COMPLETE PROMPT ===")
+                logger.info("=== GEMINI_DEBUG_LOGGING: COMPLETE PROMPT ===")
                 logger.info(f"System Instruction: {system_instruction}")
                 logger.info(f"Contents ({len(contents_norm)} turns):")
                 for i, turn in enumerate(contents_norm):
@@ -251,7 +251,7 @@ class GeminiLLM(LLM):
                             logger.info(f"    Part {j+1}: {text}")
                         else:
                             logger.info(f"    Part {j+1}: {part}")
-                logger.info("=== END GEMINI DEBUG: PROMPT ===")
+                logger.info("=== END GEMINI_DEBUG_LOGGING: PROMPT ===")
 
             # Use the new client.models.generate_content API
             model_name = model or self.model_name
@@ -292,27 +292,34 @@ class GeminiLLM(LLM):
                                     and "text" in first_part
                                 ):
                                     text = str(first_part["text"] or "")
-                break
 
-            # Optional comprehensive logging for debugging
-            if os.getenv("GEMINI_DEBUG_LOGGING", "").lower() in ("true", "1", "yes"):
-                logger.info("=== GEMINI DEBUG: COMPLETE RESPONSE ===")
-                logger.info(f"Response text: {text}")
-                if response is not None:
-                    logger.info(f"Response object type: {type(response)}")
-                    if hasattr(response, "candidates") and response.candidates:
-                        logger.info(f"Number of candidates: {len(response.candidates)}")
-                        for i, candidate in enumerate(response.candidates):
-                            logger.info(f"  Candidate {i+1}:")
-                            if hasattr(candidate, "finish_reason"):
-                                logger.info(
-                                    f"    Finish reason: {candidate.finish_reason}"
-                                )
-                            if hasattr(candidate, "safety_ratings"):
-                                logger.info(
-                                    f"    Safety ratings: {candidate.safety_ratings}"
-                                )
-                logger.info("=== END GEMINI DEBUG: RESPONSE ===")
+                # Optional comprehensive logging for debugging
+                if os.getenv("GEMINI_DEBUG_LOGGING", "").lower() in (
+                    "true",
+                    "1",
+                    "yes",
+                ):
+                    logger.info("=== GEMINI_DEBUG_LOGGING: COMPLETE RESPONSE ===")
+                    logger.info(f"Response text: {text}")
+                    if response is not None:
+                        logger.info(f"Response object type: {type(response)}")
+                        if hasattr(response, "candidates") and response.candidates:
+                            logger.info(
+                                f"Number of candidates: {len(response.candidates)}"
+                            )
+                            for i, candidate in enumerate(response.candidates):
+                                logger.info(f"  Candidate {i+1}:")
+                                if hasattr(candidate, "finish_reason"):
+                                    logger.info(
+                                        f"    Finish reason: {candidate.finish_reason}"
+                                    )
+                                if hasattr(candidate, "safety_ratings"):
+                                    logger.info(
+                                        f"    Safety ratings: {candidate.safety_ratings}"
+                                    )
+                    logger.info("=== END GEMINI_DEBUG_LOGGING: RESPONSE ===")
+
+                break
 
             return text or ""
         except Exception as e:

--- a/src/llm/gemini.py
+++ b/src/llm/gemini.py
@@ -268,31 +268,6 @@ class GeminiLLM(LLM):
                     config=config,
                 )
 
-                # Extract the first candidate's text safely
-                text = ""
-                if response is not None:
-                    if hasattr(response, "text") and isinstance(response.text, str):
-                        text = response.text
-                    elif hasattr(response, "candidates") and response.candidates:
-                        cand = response.candidates[0]
-                        if cand.finish_reason == FinishReason.PROHIBITED_CONTENT:
-                            logger.warning(
-                                "Gemini returned prohibited content, trying again"
-                            )
-                            continue  # try again
-                        t = getattr(cand, "text", None)
-                        if isinstance(t, str):
-                            text = t or ""
-                        else:
-                            content = getattr(cand, "content", None)
-                            if content and getattr(content, "parts", None):
-                                first_part = content.parts[0]
-                                if (
-                                    isinstance(first_part, dict)
-                                    and "text" in first_part
-                                ):
-                                    text = str(first_part["text"] or "")
-
                 # Optional comprehensive logging for debugging
                 if os.getenv("GEMINI_DEBUG_LOGGING", "").lower() in (
                     "true",
@@ -318,6 +293,31 @@ class GeminiLLM(LLM):
                                         f"    Safety ratings: {candidate.safety_ratings}"
                                     )
                     logger.info("=== END GEMINI_DEBUG_LOGGING: RESPONSE ===")
+
+                # Extract the first candidate's text safely
+                text = ""
+                if response is not None:
+                    if hasattr(response, "text") and isinstance(response.text, str):
+                        text = response.text
+                    elif hasattr(response, "candidates") and response.candidates:
+                        cand = response.candidates[0]
+                        if cand.finish_reason == FinishReason.PROHIBITED_CONTENT:
+                            logger.warning(
+                                "Gemini returned prohibited content, trying again"
+                            )
+                            continue  # try again
+                        t = getattr(cand, "text", None)
+                        if isinstance(t, str):
+                            text = t or ""
+                        else:
+                            content = getattr(cand, "content", None)
+                            if content and getattr(content, "parts", None):
+                                first_part = content.parts[0]
+                                if (
+                                    isinstance(first_part, dict)
+                                    and "text" in first_part
+                                ):
+                                    text = str(first_part["text"] or "")
 
                 break
 

--- a/src/media_editor.py
+++ b/src/media_editor.py
@@ -237,7 +237,18 @@ def api_media_list():
 
                 # Look for associated media file
                 media_file = None
-                for ext in [".webp", ".tgs", ".png", ".jpg", ".jpeg", ".gif", ".mp4"]:
+                for ext in [
+                    ".webp",
+                    ".tgs",
+                    ".png",
+                    ".jpg",
+                    ".jpeg",
+                    ".gif",
+                    ".mp4",
+                    ".webm",
+                    ".mov",
+                    ".avi",
+                ]:
                     potential_file = media_dir / f"{unique_id}{ext}"
                     if potential_file.exists():
                         media_file = str(potential_file)
@@ -302,7 +313,18 @@ def api_media_file(unique_id: str):
         media_dir = resolve_media_path(directory_path)
 
         # Try different extensions with proper MIME types
-        for ext in [".webp", ".tgs", ".png", ".jpg", ".jpeg", ".gif", ".mp4"]:
+        for ext in [
+            ".webp",
+            ".tgs",
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".mp4",
+            ".webm",
+            ".mov",
+            ".avi",
+        ]:
             media_file = media_dir / f"{unique_id}{ext}"
             if media_file.exists():
                 # Set appropriate MIME type for TGS files
@@ -318,6 +340,12 @@ def api_media_file(unique_id: str):
                     return send_file(media_file, mimetype="image/gif")
                 elif ext == ".mp4":
                     return send_file(media_file, mimetype="video/mp4")
+                elif ext == ".webm":
+                    return send_file(media_file, mimetype="video/webm")
+                elif ext == ".mov":
+                    return send_file(media_file, mimetype="video/quicktime")
+                elif ext == ".avi":
+                    return send_file(media_file, mimetype="video/x-msvideo")
                 else:
                     return send_file(media_file)
 
@@ -401,7 +429,18 @@ def api_refresh_from_ai(unique_id: str):
 
         # Find the media file
         media_file = None
-        for ext in [".webp", ".tgs", ".png", ".jpg", ".jpeg", ".gif", ".mp4"]:
+        for ext in [
+            ".webp",
+            ".tgs",
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".mp4",
+            ".webm",
+            ".mov",
+            ".avi",
+        ]:
             potential_file = media_dir / f"{unique_id}{ext}"
             if potential_file.exists():
                 media_file = potential_file
@@ -502,7 +541,17 @@ def api_move_media(unique_id: str):
 
         # Find the media file (could be .webp, .tgs, etc.)
         media_file_from = None
-        for ext in [".webp", ".tgs", ".gif", ".mp4", ".jpg", ".png"]:
+        for ext in [
+            ".webp",
+            ".tgs",
+            ".gif",
+            ".mp4",
+            ".webm",
+            ".mov",
+            ".avi",
+            ".jpg",
+            ".png",
+        ]:
             potential_file = from_dir / f"{unique_id}{ext}"
             if potential_file.exists():
                 media_file_from = potential_file

--- a/src/media_editor.py
+++ b/src/media_editor.py
@@ -716,6 +716,9 @@ async def _import_sticker_set_async(sticker_set_name: str, target_directory: str
     imported_count = 0
     skipped_count = 0
 
+    # Create a single DirectoryMediaSource instance outside the loop to enable in-memory caching
+    cache_source = DirectoryMediaSource(target_dir)
+
     try:
         # Download sticker set using the same pattern as run.py
         logger.info(f"Requesting sticker set: {sticker_set_name}")
@@ -843,7 +846,6 @@ async def _import_sticker_set_async(sticker_set_name: str, target_directory: str
                     }
 
                     # Save both media file and JSON record using DirectoryMediaSource
-                    cache_source = DirectoryMediaSource(target_dir)
                     cache_source.put(unique_id, media_record, media_bytes, file_ext)
 
                     imported_count += 1
@@ -863,8 +865,7 @@ async def _import_sticker_set_async(sticker_set_name: str, target_directory: str
                         "mime_type": getattr(doc, "mime_type", None),
                     }
                     # Save error record using DirectoryMediaSource (no media file for errors)
-                    cache_source = DirectoryMediaSource(target_dir)
-                    cache_source.put(unique_id, error_record)
+                    cache_source.put(unique_id, error_record, None, None)
                     imported_count += 1
 
             except Exception as e:

--- a/src/media_format.py
+++ b/src/media_format.py
@@ -50,35 +50,17 @@ async def _extract_sticker_set_name(media_item, agent, resolve_sticker_set_name)
     # Method 1: Get sticker set name from MediaItem first
     sticker_set_name = getattr(media_item, "sticker_set_name", None)
     if sticker_set_name:
-        logger.info(
-            f"[DEBUG] Found sticker set name in MediaItem for {media_item.unique_id}: '{sticker_set_name}'"
-        )
         return sticker_set_name
 
     # Method 2: If not in MediaItem, try to resolve from attributes via API
-    logger.info(
-        f"[DEBUG] Attempting to resolve sticker set name for {media_item.unique_id} from MediaItem attributes"
-    )
     try:
         sticker_set_name = await resolve_sticker_set_name(agent, media_item)
         if sticker_set_name:
-            logger.info(
-                f"[DEBUG] Successfully resolved sticker set name for {media_item.unique_id}: '{sticker_set_name}'"
-            )
             return sticker_set_name
-        else:
-            logger.warning(
-                f"[DEBUG] Failed to resolve sticker set name for {media_item.unique_id}: returned None"
-            )
-    except Exception as e:
-        logger.warning(
-            f"[DEBUG] Exception during sticker set name resolution for {media_item.unique_id}: {e}"
-        )
+    except Exception:
+        pass
 
     # Method 3: Final fallback
-    logger.debug(
-        f"[DEBUG] Sticker set name unresolved for sticker {media_item.unique_id}, using final fallback: (unknown)"
-    )
     return "(unknown)"
 
 
@@ -119,8 +101,6 @@ async def format_sticker_sentence(
         Formatted sticker sentence ready for conversation history
     """
 
-    logger.info(f"[DEBUG] Processing sticker {media_item.unique_id}")
-
     # Get sticker name from MediaItem
     sticker_name = getattr(media_item, "sticker_name", None)
 
@@ -133,11 +113,7 @@ async def format_sticker_sentence(
     meta = None
     try:
         meta = await media_chain.get(media_item.unique_id, agent=agent)
-        logger.info(f"[DEBUG] Sticker {media_item.unique_id} metadata: {meta}")
-    except Exception as e:
-        logger.warning(
-            f"[DEBUG] Failed to get metadata for {media_item.unique_id}: {e}"
-        )
+    except Exception:
         meta = None
 
     # Use the resolved sticker name, with fallback

--- a/src/media_format.py
+++ b/src/media_format.py
@@ -3,6 +3,10 @@
 # Copyright (c) 2025 Cindy's World LLC and contributors
 # Licensed under the MIT License. See LICENSE.md for details.
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 """
 Formatting helpers for media descriptions and message text.
 
@@ -26,10 +30,63 @@ def format_media_description(description: str | None) -> str:
     return f"that appears as {s}"
 
 
-def format_sticker_sentence(
+async def _extract_sticker_set_name(media_item, agent, resolve_sticker_set_name) -> str:
+    """
+    Extract sticker set name using all available methods in order of preference.
+
+    This function tries multiple approaches:
+    1. Get from MediaItem.sticker_set_name (if already resolved)
+    2. Resolve via API using resolve_sticker_set_name function
+    3. Return "(unknown)" as final fallback
+
+    Args:
+        media_item: The MediaItem object containing sticker information
+        agent: Telegram agent for API calls
+        resolve_sticker_set_name: Function to resolve sticker set names via API
+
+    Returns:
+        Resolved sticker set name, never None
+    """
+    # Method 1: Get sticker set name from MediaItem first
+    sticker_set_name = getattr(media_item, "sticker_set_name", None)
+    if sticker_set_name:
+        logger.info(
+            f"[DEBUG] Found sticker set name in MediaItem for {media_item.unique_id}: '{sticker_set_name}'"
+        )
+        return sticker_set_name
+
+    # Method 2: If not in MediaItem, try to resolve from attributes via API
+    logger.info(
+        f"[DEBUG] Attempting to resolve sticker set name for {media_item.unique_id} from MediaItem attributes"
+    )
+    try:
+        sticker_set_name = await resolve_sticker_set_name(agent, media_item)
+        if sticker_set_name:
+            logger.info(
+                f"[DEBUG] Successfully resolved sticker set name for {media_item.unique_id}: '{sticker_set_name}'"
+            )
+            return sticker_set_name
+        else:
+            logger.warning(
+                f"[DEBUG] Failed to resolve sticker set name for {media_item.unique_id}: returned None"
+            )
+    except Exception as e:
+        logger.warning(
+            f"[DEBUG] Exception during sticker set name resolution for {media_item.unique_id}: {e}"
+        )
+
+    # Method 3: Final fallback
+    logger.debug(
+        f"[DEBUG] Sticker set name unresolved for sticker {media_item.unique_id}, using final fallback: (unknown)"
+    )
+    return "(unknown)"
+
+
+def _format_sticker_sentence_internal(
     sticker_name: str, sticker_set_name: str, description: str | None
 ) -> str:
     """
+    Internal helper for formatting sticker sentences.
     Full sticker sentence:
       the sticker `<name>` from the sticker set `<set>` that appears as ‹…›
     Falls back to 'that is not understood' when description is missing/unsupported.
@@ -37,6 +94,64 @@ def format_sticker_sentence(
     base = f"the sticker `{sticker_name}` from the sticker set `{sticker_set_name}`"
     s = (description or "").strip()
     return f"[media] {ANGLE_OPEN}{base} {format_media_description(s)}{ANGLE_CLOSE}"
+
+
+async def format_sticker_sentence(
+    media_item, agent, media_chain, resolve_sticker_set_name
+) -> str:
+    """
+    Process a sticker MediaItem and return a formatted sentence.
+
+    This function handles:
+    - Extracting sticker name from MediaItem attributes
+    - Resolving sticker set name (from MediaItem or via API)
+    - Retrieving cached metadata/descriptions
+    - Fallback handling for unresolved names
+    - Final formatting using the internal helper
+
+    Args:
+        media_item: The MediaItem object containing sticker information
+        agent: Telegram agent for API calls
+        media_chain: Media cache for retrieving descriptions
+        resolve_sticker_set_name: Function to resolve sticker set names via API
+
+    Returns:
+        Formatted sticker sentence ready for conversation history
+    """
+
+    logger.info(f"[DEBUG] Processing sticker {media_item.unique_id}")
+
+    # Get sticker name from MediaItem
+    sticker_name = getattr(media_item, "sticker_name", None)
+
+    # Extract sticker set name using all available methods
+    sticker_set_name = await _extract_sticker_set_name(
+        media_item, agent, resolve_sticker_set_name
+    )
+
+    # Check if we already have cached metadata
+    meta = None
+    try:
+        meta = await media_chain.get(media_item.unique_id, agent=agent)
+        logger.info(f"[DEBUG] Sticker {media_item.unique_id} metadata: {meta}")
+    except Exception as e:
+        logger.warning(
+            f"[DEBUG] Failed to get metadata for {media_item.unique_id}: {e}"
+        )
+        meta = None
+
+    # Use the resolved sticker name, with fallback
+    if not sticker_name:
+        sticker_name = "(unnamed)"
+
+    # Get raw description from cache for format_sticker_sentence
+    desc_text = meta.get("description") if isinstance(meta, dict) else None
+
+    return _format_sticker_sentence_internal(
+        sticker_name=sticker_name,
+        sticker_set_name=sticker_set_name,
+        description=desc_text,
+    )
 
 
 def format_media_sentence(kind: str, description: str | None) -> str:

--- a/src/media_injector.py
+++ b/src/media_injector.py
@@ -331,29 +331,27 @@ async def format_message_for_prompt(msg: Any, *, agent, media_chain=None) -> str
         items = []
 
     for it in items:
-        meta = await media_chain.get(it.unique_id, agent=agent)
+        # First, try to resolve sticker information from the MediaItem itself
+        sticker_set_name = None
+        sticker_name = None
 
         if it.kind == "sticker":
             logger.info(f"[DEBUG] Processing sticker {it.unique_id}")
 
-            # Try to get sticker set name from metadata first
-            sticker_set_name = None
-            if isinstance(meta, dict):
-                sticker_set_name = meta.get("sticker_set_name")
-                logger.info(f"[DEBUG] Sticker {it.unique_id} metadata: {meta}")
-                if sticker_set_name:
-                    logger.info(
-                        f"[DEBUG] Found cached sticker set name for {it.unique_id}: '{sticker_set_name}'"
-                    )
-                else:
-                    logger.info(
-                        f"[DEBUG] No cached sticker set name for {it.unique_id}"
-                    )
+            # Get sticker name from MediaItem
+            sticker_name = getattr(it, "sticker_name", None)
 
-            # If not in metadata, try to resolve from the MediaItem
+            # Get sticker set name from MediaItem first
+            sticker_set_name = getattr(it, "sticker_set_name", None)
+            if sticker_set_name:
+                logger.info(
+                    f"[DEBUG] Found sticker set name in MediaItem for {it.unique_id}: '{sticker_set_name}'"
+                )
+
+            # If not in MediaItem, try to resolve from attributes
             if not sticker_set_name:
                 logger.info(
-                    f"[DEBUG] Attempting to resolve sticker set name for {it.unique_id} from MediaItem"
+                    f"[DEBUG] Attempting to resolve sticker set name for {it.unique_id} from MediaItem attributes"
                 )
                 try:
                     sticker_set_name = await _maybe_get_sticker_set_short_name(
@@ -371,6 +369,20 @@ async def format_message_for_prompt(msg: Any, *, agent, media_chain=None) -> str
                     logger.warning(
                         f"[DEBUG] Exception during sticker set name resolution for {it.unique_id}: {e}"
                     )
+
+        # Only call media_chain.get() if we need cached metadata (like descriptions)
+        # Don't call it if we already have the sticker information resolved
+        meta = None
+        if it.kind == "sticker":
+            # Check if we already have cached metadata
+            try:
+                meta = await media_chain.get(it.unique_id, agent=agent)
+                logger.info(f"[DEBUG] Sticker {it.unique_id} metadata: {meta}")
+            except Exception as e:
+                logger.warning(
+                    f"[DEBUG] Failed to get metadata for {it.unique_id}: {e}"
+                )
+                meta = None
 
             # Final fallback - try to use a more descriptive fallback
             if not sticker_set_name:
@@ -396,11 +408,10 @@ async def format_message_for_prompt(msg: Any, *, agent, media_chain=None) -> str
                 logger.debug(
                     f"Sticker set name unresolved for sticker {it.unique_id}, using fallback: {sticker_set_name}"
                 )
-            sticker_name = (
-                (meta.get("sticker_name") if isinstance(meta, dict) else None)
-                or getattr(it, "sticker_name", None)
-                or "(unnamed)"
-            )
+
+            # Use the resolved sticker name, with fallback
+            if not sticker_name:
+                sticker_name = "(unnamed)"
             # Get raw description from cache for format_sticker_sentence
             desc_text = meta.get("description") if isinstance(meta, dict) else None
             parts.append(

--- a/src/media_injector.py
+++ b/src/media_injector.py
@@ -31,34 +31,22 @@ async def _maybe_get_sticker_set_short_name(agent, it) -> str | None:
     - Else call messages.GetStickerSet with hash=0 (forces fetch), passing the existing
       stickerset object when possible; fall back to constructing InputStickerSetID.
     """
-    logger.info(f"[DEBUG] Starting sticker set name resolution for {it.unique_id}")
 
     doc = getattr(it, "file_ref", None)
     if not doc:
-        logger.warning(f"[DEBUG] No file_ref found for {it.unique_id}")
         return None
 
     attrs = getattr(doc, "attributes", None)
     if not isinstance(attrs, (list, tuple)):
-        logger.warning(
-            f"[DEBUG] No attributes found for {it.unique_id}, attrs type: {type(attrs)}"
-        )
         return None
 
-    logger.info(f"[DEBUG] Found {len(attrs)} attributes for {it.unique_id}")
-
     ss = None
-    for i, a in enumerate(attrs):
-        logger.info(f"[DEBUG] Attribute {i}: {type(a).__name__}")
+    for _i, a in enumerate(attrs):
         if hasattr(a, "stickerset"):
             ss = getattr(a, "stickerset", None)
-            logger.info(
-                f"[DEBUG] Found stickerset attribute: {type(ss).__name__ if ss else None}"
-            )
             break
 
     if ss is None:
-        logger.warning(f"[DEBUG] No stickerset found in attributes for {it.unique_id}")
         return None
 
     # Check for direct name fields
@@ -66,43 +54,20 @@ async def _maybe_get_sticker_set_short_name(agent, it) -> str | None:
     name = getattr(ss, "name", None)
     title = getattr(ss, "title", None)
 
-    logger.info(
-        f"[DEBUG] StickerSet fields for {it.unique_id}: short_name='{short_name}', name='{name}', title='{title}'"
-    )
-
     direct = short_name or name or title
     if isinstance(direct, str) and direct.strip():
-        logger.info(
-            f"[DEBUG] Found direct sticker set name for {it.unique_id}: '{direct.strip()}'"
-        )
         return direct.strip()
 
-    logger.info(f"[DEBUG] No direct name found, attempting API call for {it.unique_id}")
-
     try:
-        logger.info(
-            f"[DEBUG] Attempting first API call for {it.unique_id} with stickerset object"
-        )
         try:
             result = await agent.client(GetStickerSetRequest(stickerset=ss, hash=0))
-            logger.info(f"[DEBUG] First API call succeeded for {it.unique_id}")
-        except TypeError as e:
-            logger.info(
-                f"[DEBUG] First API call failed with TypeError for {it.unique_id}: {e}"
-            )
+        except TypeError:
             set_id = getattr(ss, "id", None)
             access_hash = getattr(ss, "access_hash", None) or getattr(
                 ss, "access", None
             )
 
-            logger.info(
-                f"[DEBUG] StickerSet ID fields for {it.unique_id}: id={set_id}, access_hash={access_hash}"
-            )
-
             if isinstance(set_id, int) and isinstance(access_hash, int):
-                logger.info(
-                    f"[DEBUG] Attempting second API call with InputStickerSetID for {it.unique_id}"
-                )
                 result = await agent.client(
                     GetStickerSetRequest(
                         stickerset=InputStickerSetID(
@@ -111,45 +76,24 @@ async def _maybe_get_sticker_set_short_name(agent, it) -> str | None:
                         hash=0,
                     )
                 )
-                logger.info(f"[DEBUG] Second API call succeeded for {it.unique_id}")
             else:
-                logger.warning(
-                    f"[DEBUG] Cannot make API call for {it.unique_id}: missing ID or access_hash"
-                )
                 return None
-        except Exception as e:
-            logger.error(f"[DEBUG] API call failed for {it.unique_id}: {e}")
-            return None
 
         st = getattr(result, "set", None)
         if not st:
-            logger.warning(f"[DEBUG] No 'set' field in API result for {it.unique_id}")
             return None
 
         api_short_name = getattr(st, "short_name", None)
         api_name = getattr(st, "name", None)
         api_title = getattr(st, "title", None)
 
-        logger.info(
-            f"[DEBUG] API result fields for {it.unique_id}: short_name='{api_short_name}', name='{api_name}', title='{api_title}'"
-        )
-
         resolved = api_short_name or api_name or api_title
         if isinstance(resolved, str) and resolved.strip():
-            logger.info(
-                f"[DEBUG] Successfully resolved sticker set name for {it.unique_id}: '{resolved.strip()}'"
-            )
             return resolved.strip()
         else:
-            logger.warning(
-                f"[DEBUG] API call succeeded but no name found for {it.unique_id}"
-            )
             return None
 
     except Exception as e:
-        logger.error(
-            f"[DEBUG] Exception in sticker set name resolution for {it.unique_id}: {e}"
-        )
         logger.exception(f"Failed to get sticker set short name: {e}")
         return None
 

--- a/src/media_source.py
+++ b/src/media_source.py
@@ -16,6 +16,7 @@ import os
 import time
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +24,6 @@ import httpx
 
 from media_budget import (
     consume_description_budget,
-    debug_save_media,
     has_description_budget,
 )
 from mime_utils import (
@@ -34,6 +34,38 @@ from prompt_loader import get_config_directories
 from telegram_download import download_media_bytes
 
 logger = logging.getLogger(__name__)
+
+
+class MediaStatus(Enum):
+    """Standardized status values for media records."""
+
+    GENERATED = "generated"  # AI successfully generated description
+    BUDGET_EXHAUSTED = "budget_exhausted"  # Budget limits reached (temporary)
+    UNSUPPORTED = "unsupported"  # Media format not supported (permanent)
+    TEMPORARY_FAILURE = "temporary_failure"  # Download failed, timeout, etc.
+    PERMANENT_FAILURE = "permanent_failure"  # API misuse, permanent errors
+
+    @classmethod
+    def is_temporary_failure(cls, status):
+        """Check if a status represents a temporary failure that should be retried."""
+        if isinstance(status, cls):
+            return status in [cls.BUDGET_EXHAUSTED, cls.TEMPORARY_FAILURE]
+        return status in [cls.BUDGET_EXHAUSTED.value, cls.TEMPORARY_FAILURE.value]
+
+    @classmethod
+    def is_permanent_failure(cls, status):
+        """Check if a status represents a permanent failure that should not be retried."""
+        if isinstance(status, cls):
+            return status in [cls.UNSUPPORTED, cls.PERMANENT_FAILURE]
+        return status in [cls.UNSUPPORTED.value, cls.PERMANENT_FAILURE.value]
+
+    @classmethod
+    def is_successful(cls, status):
+        """Check if a status represents successful generation."""
+        if isinstance(status, cls):
+            return status == cls.GENERATED
+        return status == cls.GENERATED.value
+
 
 # Timeout for LLM description
 _DESCRIBE_TIMEOUT_SECS = 12
@@ -174,6 +206,49 @@ class DirectoryMediaSource(MediaSource):
         )
         return None
 
+    def put(
+        self,
+        unique_id: str,
+        record: dict[str, Any],
+        media_bytes: bytes = None,
+        file_extension: str = None,
+    ) -> None:
+        """Store metadata record and optionally media file to disk."""
+        # Always store the JSON metadata
+        self._write_to_disk(unique_id, record)
+
+        # Optionally store media file if provided
+        if media_bytes and file_extension:
+            media_file = self.directory / f"{unique_id}{file_extension}"
+            media_file.write_bytes(media_bytes)
+            logger.debug(f"DirectoryMediaSource: stored media file {media_file.name}")
+
+    def _write_to_disk(self, unique_id: str, record: dict[str, Any]) -> None:
+        """Write a record to disk cache and update in-memory cache."""
+        try:
+            file_path = self.directory / f"{unique_id}.json"
+            temp_path = self.directory / f"{unique_id}.json.tmp"
+
+            # Mark record as stored on disk
+            record["_on_disk"] = True
+
+            # Write to temporary file first, then atomically rename
+            temp_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+            temp_path.replace(file_path)
+
+            logger.debug(f"DirectoryMediaSource: cached {unique_id} to disk")
+
+            # Update the in-memory cache
+            self._mem_cache[unique_id] = record
+            logger.debug(
+                f"DirectoryMediaSource: updated in-memory cache for {unique_id}"
+            )
+
+        except Exception as e:
+            logger.exception(
+                f"DirectoryMediaSource: failed to cache {unique_id} to disk: {e}"
+            )
+
 
 class CompositeMediaSource(MediaSource):
     """
@@ -276,14 +351,15 @@ class BudgetExhaustedMediaSource(MediaSource):
                 "sticker_set_name": sticker_set_name,
                 "sticker_name": sticker_name,
                 "description": None,
-                "status": "budget_exhausted",
+                "status": MediaStatus.BUDGET_EXHAUSTED.value,
                 "ts": datetime.now(UTC).isoformat(),
+                "_on_disk": False,
             }
 
 
 def make_error_record(
     unique_id: str,
-    status: str,
+    status,
     failure_reason: str,
     retryable: bool = False,
     kind: str | None = None,
@@ -292,15 +368,17 @@ def make_error_record(
     **extra,
 ) -> dict[str, Any]:
     """Helper to create an error record."""
+    status_value = status.value if isinstance(status, MediaStatus) else status
     record = {
         "unique_id": unique_id,
         "kind": kind,
         "sticker_set_name": sticker_set_name,
         "sticker_name": sticker_name,
         "description": None,
-        "status": status,
+        "status": status_value,
         "failure_reason": failure_reason,
         "ts": datetime.now(UTC).isoformat(),
+        "_on_disk": False,  # Track whether this record is stored on disk
         **extra,
     }
     if retryable:
@@ -354,7 +432,7 @@ class UnsupportedFormatMediaSource(MediaSource):
                 # Return unsupported format record
                 return make_error_record(
                     unique_id,
-                    "unsupported_format",
+                    MediaStatus.UNSUPPORTED,
                     f"MIME type {mime_type} not supported by LLM",
                     kind=kind,
                     sticker_set_name=sticker_set_name,
@@ -372,27 +450,25 @@ class UnsupportedFormatMediaSource(MediaSource):
 
 class AIGeneratingMediaSource(MediaSource):
     """
-    Generates media descriptions using AI and caches them to disk.
+    Generates media descriptions using AI.
 
     This source always succeeds (never returns None). It either:
-    1. Successfully generates and caches a description
-    2. Caches an "unsupported format" record (no LLM call)
-    3. Returns a transient failure fallback (no disk cache)
+    1. Successfully generates a description
+    2. Returns a transient failure record (timeouts, etc.)
+    3. Returns a permanent failure record (LLM errors, etc.)
+
+    Caching is handled by the calling AIChainMediaSource.
     """
 
-    def __init__(
-        self, cache_directory: Path, cache_source: DirectoryMediaSource | None = None
-    ):
+    def __init__(self, cache_directory: Path):
         """
         Initialize the AI generating source.
 
         Args:
-            cache_directory: Directory to store generated descriptions
-            cache_source: Optional DirectoryMediaSource to update in-memory cache
+            cache_directory: Directory for debug saves (no longer used for caching)
         """
         self.cache_directory = Path(cache_directory)
         self.cache_directory.mkdir(parents=True, exist_ok=True)
-        self.cache_source = cache_source
 
     async def get(
         self,
@@ -412,44 +488,17 @@ class AIGeneratingMediaSource(MediaSource):
         """
 
         if agent is None:
-            logger.error("AIGeneratingMediaSource: agent is required but was None")
-            return make_error_record(
-                unique_id,
-                "error",
-                "agent is None",
-                kind=kind,
-                sticker_set_name=sticker_set_name,
-                sticker_name=sticker_name,
-                **metadata,
-            )
+            raise ValueError("AIGeneratingMediaSource: agent is required but was None")
 
         if doc is None:
-            logger.error("AIGeneratingMediaSource: doc is required but was None")
-            return make_error_record(
-                unique_id,
-                "error",
-                "doc is None",
-                kind=kind,
-                sticker_set_name=sticker_set_name,
-                sticker_name=sticker_name,
-                **metadata,
-            )
+            raise ValueError("AIGeneratingMediaSource: doc is required but was None")
 
         client = getattr(agent, "client", None)
         llm = getattr(agent, "llm", None)
 
         if not client or not llm:
-            logger.error(
+            raise ValueError(
                 f"AIGeneratingMediaSource: agent missing client or llm for {unique_id}"
-            )
-            return make_error_record(
-                unique_id,
-                "error",
-                "agent missing client or llm",
-                kind=kind,
-                sticker_set_name=sticker_set_name,
-                sticker_name=sticker_name,
-                **metadata,
             )
 
         # Special handling for AnimatedEmojies - use sticker name as description
@@ -463,8 +512,9 @@ class AIGeneratingMediaSource(MediaSource):
                 "sticker_set_name": sticker_set_name,
                 "sticker_name": sticker_name,
                 "description": sticker_name,  # Use the emoji name as description
-                "status": "ok",
+                "status": MediaStatus.GENERATED.value,
                 "ts": datetime.now(UTC).isoformat(),
+                "_on_disk": False,
                 **metadata,
             }
 
@@ -483,7 +533,7 @@ class AIGeneratingMediaSource(MediaSource):
             # Transient failure - don't cache to disk
             return make_error_record(
                 unique_id,
-                "error",
+                MediaStatus.TEMPORARY_FAILURE,
                 f"download failed: {str(e)[:100]}",
                 retryable=True,
                 kind=kind,
@@ -509,14 +559,10 @@ class AIGeneratingMediaSource(MediaSource):
                 f"AIGeneratingMediaSource: timeout after {_DESCRIBE_TIMEOUT_SECS}s for {unique_id}"
             )
 
-            # Debug save
-            file_ext = get_file_extension_for_mime_type(detected_mime_type)
-            debug_save_media(data, unique_id, file_ext)
-
-            # Transient failure - don't cache to disk
+            # Transient failure - return error record for AIChainMediaSource to handle
             return make_error_record(
                 unique_id,
-                "timeout",
+                MediaStatus.TEMPORARY_FAILURE,
                 f"timeout after {_DESCRIBE_TIMEOUT_SECS}s",
                 retryable=True,
                 kind=kind,
@@ -529,33 +575,23 @@ class AIGeneratingMediaSource(MediaSource):
                 f"AIGeneratingMediaSource: LLM failed for {unique_id}: {e}"
             )
 
-            # Debug save
-            file_ext = get_file_extension_for_mime_type(detected_mime_type)
-            debug_save_media(data, unique_id, file_ext)
-
-            # Cache permanent failure to disk
-            record = make_error_record(
+            # Permanent failure - return error record for AIChainMediaSource to handle
+            return make_error_record(
                 unique_id,
-                "error",
+                MediaStatus.PERMANENT_FAILURE,
                 f"description failed: {str(e)[:100]}",
                 kind=kind,
                 sticker_set_name=sticker_set_name,
                 sticker_name=sticker_name,
                 **metadata,
             )
-            self._write_to_disk(unique_id, record)
-            return record
 
         llm_ms = (time.perf_counter() - t1) * 1000
 
         # Determine status
-        status = "ok" if desc else "not_understood"
+        status = MediaStatus.GENERATED if desc else MediaStatus.PERMANENT_FAILURE
 
-        # Debug save
-        file_ext = get_file_extension_for_mime_type(detected_mime_type)
-        debug_save_media(data, unique_id, file_ext)
-
-        # Cache result to disk
+        # Return record for AIChainMediaSource to handle caching
         record = {
             "unique_id": unique_id,
             "kind": kind,
@@ -565,14 +601,14 @@ class AIGeneratingMediaSource(MediaSource):
             "failure_reason": (
                 "LLM returned empty or invalid description" if not desc else None
             ),
-            "status": status,
+            "status": status.value,
             "ts": datetime.now(UTC).isoformat(),
+            "_on_disk": False,  # Will be set to True by AIChainMediaSource
             **metadata,
         }
-        self._write_to_disk(unique_id, record)
 
         total_ms = (time.perf_counter() - t0) * 1000
-        if status == "ok":
+        if status == MediaStatus.GENERATED:
             logger.debug(
                 f"AIGeneratingMediaSource: SUCCESS {unique_id} bytes={len(data)} dl={dl_ms:.0f}ms llm={llm_ms:.0f}ms total={total_ms:.0f}ms"
             )
@@ -583,29 +619,146 @@ class AIGeneratingMediaSource(MediaSource):
 
         return record
 
-    def _write_to_disk(self, unique_id: str, record: dict[str, Any]) -> None:
-        """Write a record to disk cache and update in-memory cache if available."""
-        try:
-            file_path = self.cache_directory / f"{unique_id}.json"
-            temp_path = self.cache_directory / f"{unique_id}.json.tmp"
 
-            # Write to temporary file first, then atomically rename
-            temp_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
-            temp_path.replace(file_path)
+class AIChainMediaSource(MediaSource):
+    """
+    Orchestrates caching and chaining of media sources with proper temporary failure handling.
 
-            logger.debug(f"AIGeneratingMediaSource: cached {unique_id} to disk")
+    This source manages the flow between:
+    1. Cache source (for persistent storage)
+    2. Unsupported format source (to avoid budget consumption)
+    3. Budget source (to limit processing)
+    4. AI generating source (for actual description generation)
 
-            # Also update the in-memory cache if we have a reference to it
-            if self.cache_source is not None:
-                self.cache_source._mem_cache[unique_id] = record
-                logger.debug(
-                    f"AIGeneratingMediaSource: updated in-memory cache for {unique_id}"
-                )
+    Key behaviors:
+    - Non-temporary cached records are returned immediately
+    - Temporary failures (budget exhaustion, timeouts) are retried
+    - Avoids storing new temporary failures when replacing cached temporary failures
+    - Optimizes downloads by passing doc=None when media is already cached
+    """
 
-        except Exception as e:
-            logger.exception(
-                f"AIGeneratingMediaSource: failed to cache {unique_id} to disk: {e}"
+    def __init__(
+        self,
+        cache_source: MediaSource,
+        unsupported_source: MediaSource,
+        budget_source: MediaSource,
+        ai_source: MediaSource,
+    ):
+        """
+        Initialize the AI chain source.
+
+        Args:
+            cache_source: Source for persistent cache storage
+            unsupported_source: Source to check unsupported formats
+            budget_source: Source to manage budget limits
+            ai_source: Source for AI generation
+        """
+        self.cache_source = cache_source
+        self.unsupported_source = unsupported_source
+        self.budget_source = budget_source
+        self.ai_source = ai_source
+
+    async def get(
+        self,
+        unique_id: str,
+        agent: Any = None,
+        doc: Any = None,
+        **metadata,
+    ) -> dict[str, Any]:
+        """
+        Get media description with proper caching and temporary failure handling.
+
+        Returns:
+            Media record with description, status, and metadata
+        """
+        # 1. Try cache first
+        cached_record = await self.cache_source.get(unique_id, agent, doc)
+
+        # 2. If we have a cached record that's NOT temporary failure, return it
+        if cached_record and not MediaStatus.is_temporary_failure(
+            cached_record.get("status")
+        ):
+            return cached_record
+
+        # 3. Chain through sources (skip download if we have cached doc)
+        record = None
+        doc_already_cached = cached_record is not None  # We have doc from cache
+
+        for source in [self.unsupported_source, self.budget_source, self.ai_source]:
+            record = await source.get(
+                unique_id, agent, doc if not doc_already_cached else None, **metadata
             )
+            if record:
+                break
+
+        # 4. Store if we got a new record and it's not another temporary failure
+        if record and not record.get("_on_disk", False):
+            should_store = True
+
+            # Don't store if it's another temporary failure replacing a cached temporary failure
+            if (
+                cached_record
+                and MediaStatus.is_temporary_failure(cached_record.get("status"))
+                and MediaStatus.is_temporary_failure(record.get("status"))
+            ):
+                should_store = False
+
+            if should_store:
+                record["_on_disk"] = True
+
+                # Check if we need to download and store the media file
+                media_bytes = None
+                file_extension = None
+
+                # Only download if we don't already have the media file on disk
+                media_file_exists = False
+                if isinstance(self.cache_source, DirectoryMediaSource):
+                    # Check if media file already exists
+                    for ext in [
+                        ".webp",
+                        ".tgs",
+                        ".png",
+                        ".jpg",
+                        ".jpeg",
+                        ".gif",
+                        ".mp4",
+                        ".webm",
+                        ".mov",
+                        ".avi",
+                    ]:
+                        media_file = self.cache_source.directory / f"{unique_id}{ext}"
+                        if media_file.exists():
+                            media_file_exists = True
+                            break
+
+                # Download media if we have a doc and media file doesn't exist
+                if not media_file_exists and doc is not None and agent is not None:
+                    try:
+                        logger.debug(
+                            f"AIChainMediaSource: downloading media for {unique_id}"
+                        )
+                        media_bytes = await download_media_bytes(agent.client, doc)
+
+                        # Get file extension from MIME type
+                        mime_type = getattr(doc, "mime_type", None)
+                        if mime_type:
+                            file_extension = get_file_extension_for_mime_type(mime_type)
+                            if file_extension:
+                                file_extension = f".{file_extension}"
+
+                        logger.debug(
+                            f"AIChainMediaSource: downloaded {len(media_bytes)} bytes for {unique_id}, extension: {file_extension}"
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"AIChainMediaSource: failed to download media for {unique_id}: {e}"
+                        )
+                        # Continue without media file - metadata is still valuable
+
+                # Store record with optional media file
+                self.cache_source.put(unique_id, record, media_bytes, file_extension)
+
+        return record
 
 
 # ---------- singleton helpers ----------
@@ -637,29 +790,27 @@ def _create_default_chain() -> CompositeMediaSource:
 
     sources: list[MediaSource] = []
 
-    # Add config directories (curated descriptions)
+    # Add config directories (curated descriptions) - checked first
     for config_dir in get_config_directories():
         media_dir = Path(config_dir) / "media"
         if media_dir.exists() and media_dir.is_dir():
             sources.append(DirectoryMediaSource(media_dir))
             logger.info(f"Added curated media directory: {media_dir}")
 
-    # Add AI cache directory
+    # Set up AI cache directory
     state_dir = Path(os.environ.get("CINDY_AGENT_STATE_DIR", "state"))
     ai_cache_dir = state_dir / "media"
     ai_cache_dir.mkdir(parents=True, exist_ok=True)
     ai_cache_source = DirectoryMediaSource(ai_cache_dir)
-    sources.append(ai_cache_source)
     logger.info(f"Added AI cache directory: {ai_cache_dir}")
 
-    # Add unsupported format check (before budget management)
-    sources.append(UnsupportedFormatMediaSource())
-
-    # Add budget management and AI generation
-    sources.append(BudgetExhaustedMediaSource())
+    # Add AI chain source that orchestrates unsupported/budget/AI generation
     sources.append(
-        AIGeneratingMediaSource(
-            cache_directory=ai_cache_dir, cache_source=ai_cache_source
+        AIChainMediaSource(
+            cache_source=ai_cache_source,
+            unsupported_source=UnsupportedFormatMediaSource(),
+            budget_source=BudgetExhaustedMediaSource(),
+            ai_source=AIGeneratingMediaSource(cache_directory=ai_cache_dir),
         )
     )
 

--- a/src/media_source.py
+++ b/src/media_source.py
@@ -65,7 +65,7 @@ class MediaSource(ABC):
             unique_id: The Telegram file unique ID
             agent: The agent instance (for accessing client, LLM, etc.)
             doc: The Telegram document reference (for downloading)
-            kind: Media type (sticker, photo, gif, animation)
+            kind: Media type (sticker, photo, gif, animation, video, animated_sticker)
             sticker_set_name: Sticker set name (if applicable)
             sticker_name: Sticker name/emoji (if applicable)
             **metadata: Additional metadata (sender_id, channel_id, etc.)

--- a/src/media_types.py
+++ b/src/media_types.py
@@ -9,7 +9,9 @@ from typing import Any, Literal
 
 @dataclass
 class MediaItem:
-    kind: Literal["photo", "sticker", "gif", "png", "animation"]
+    kind: Literal[
+        "photo", "sticker", "gif", "png", "animation", "video", "animated_sticker"
+    ]
     unique_id: str  # REQUIRED stable ID (e.g., Telegram file_unique_id)
     mime: str | None = None
     sticker_set_name: str | None = None

--- a/src/mime_utils.py
+++ b/src/mime_utils.py
@@ -83,6 +83,7 @@ def get_file_extension_for_mime_type(mime_type: str) -> str:
         "audio/wav": "wav",
         "audio/mp4": "m4a",
         "application/gzip": "tgs",  # TGS files are gzip-compressed
+        "application/x-tgsticker": "tgs",  # Telegram animated stickers
         "application/zip": "zip",
         "application/octet-stream": "bin",
     }

--- a/src/mime_utils.py
+++ b/src/mime_utils.py
@@ -27,9 +27,15 @@ def detect_mime_type_from_bytes(data: bytes) -> str:
 
     # Video formats
     elif data[4:8] == b"ftyp":  # MP4 family (video/mp4, audio/mp4)
-        return "video/mp4"
+        # Check for QuickTime/MOV specific brand
+        if len(data) >= 12 and data[8:12] == b"qt  ":
+            return "video/quicktime"
+        else:
+            return "video/mp4"
     elif data[:4] == b"\x1a\x45\xdf\xa3":  # WebM/Matroska (EBML)
         return "video/webm"
+    elif data[:4] == b"RIFF" and data[8:12] == b"AVI ":  # AVI
+        return "video/x-msvideo"
 
     # Audio formats
     elif data.startswith(b"ID3") or data[0:4] == b"\xff\xfb":  # MP3
@@ -69,6 +75,8 @@ def get_file_extension_for_mime_type(mime_type: str) -> str:
         "image/webp": "webp",
         "video/mp4": "mp4",
         "video/webm": "webm",
+        "video/quicktime": "mov",
+        "video/x-msvideo": "avi",
         "audio/mpeg": "mp3",
         "audio/ogg": "ogg",
         "audio/flac": "flac",

--- a/src/telegram_media.py
+++ b/src/telegram_media.py
@@ -77,23 +77,12 @@ def _maybe_add_sticker(msg: Any, out: list[MediaItem]) -> None:
                     emoji_name = getattr(doc, "emoji", None)
                     file_name = getattr(doc, "file_name", None)
 
-                    logger.info(
-                        f"[DEBUG] Sticker name extraction for {uid}: alt='{alt_name}', emoji='{emoji_name}', file_name='{file_name}'"
-                    )
-
                     name = alt_name or emoji_name or file_name
                     # sticker set short name if present directly on attribute
                     ss = getattr(a, "stickerset", None)
                     short_name = getattr(ss, "short_name", None)
                     ss_name = getattr(ss, "name", None)
                     title = getattr(ss, "title", None)
-
-                    logger.info(
-                        f"[DEBUG] Creating MediaItem for sticker {uid}: stickerset type={type(ss).__name__ if ss else None}"
-                    )
-                    logger.info(
-                        f"[DEBUG] StickerSet fields: short_name='{short_name}', name='{ss_name}', title='{title}'"
-                    )
 
                     sticker_set_name = short_name or ss_name or title
                     mime = getattr(doc, "mime_type", None) or getattr(doc, "mime", None)

--- a/src/telegram_media.py
+++ b/src/telegram_media.py
@@ -3,9 +3,12 @@
 # Copyright (c) 2025 Cindy's World LLC and contributors
 # Licensed under the MIT License. See LICENSE.md for details.
 
+import logging
 from typing import Any
 
 from media_types import MediaItem
+
+logger = logging.getLogger(__name__)
 
 
 def iter_media_parts(msg: Any) -> list[MediaItem]:
@@ -77,11 +80,18 @@ def _maybe_add_sticker(msg: Any, out: list[MediaItem]) -> None:
                     )
                     # sticker set short name if present directly on attribute
                     ss = getattr(a, "stickerset", None)
-                    sticker_set_name = (
-                        getattr(ss, "short_name", None)
-                        or getattr(ss, "name", None)
-                        or getattr(ss, "title", None)
+                    short_name = getattr(ss, "short_name", None)
+                    name = getattr(ss, "name", None)
+                    title = getattr(ss, "title", None)
+
+                    logger.info(
+                        f"[DEBUG] Creating MediaItem for sticker {uid}: stickerset type={type(ss).__name__ if ss else None}"
                     )
+                    logger.info(
+                        f"[DEBUG] StickerSet fields: short_name='{short_name}', name='{name}', title='{title}'"
+                    )
+
+                    sticker_set_name = short_name or name or title
                     mime = getattr(doc, "mime_type", None) or getattr(doc, "mime", None)
                     out.append(
                         MediaItem(

--- a/src/telegram_media.py
+++ b/src/telegram_media.py
@@ -73,25 +73,29 @@ def _maybe_add_sticker(msg: Any, out: list[MediaItem]) -> None:
                     if not uid:
                         return
                     # sticker name (emoji/alt/file_name)
-                    name = (
-                        getattr(a, "alt", None)
-                        or getattr(doc, "emoji", None)
-                        or getattr(doc, "file_name", None)
+                    alt_name = getattr(a, "alt", None)
+                    emoji_name = getattr(doc, "emoji", None)
+                    file_name = getattr(doc, "file_name", None)
+
+                    logger.info(
+                        f"[DEBUG] Sticker name extraction for {uid}: alt='{alt_name}', emoji='{emoji_name}', file_name='{file_name}'"
                     )
+
+                    name = alt_name or emoji_name or file_name
                     # sticker set short name if present directly on attribute
                     ss = getattr(a, "stickerset", None)
                     short_name = getattr(ss, "short_name", None)
-                    name = getattr(ss, "name", None)
+                    ss_name = getattr(ss, "name", None)
                     title = getattr(ss, "title", None)
 
                     logger.info(
                         f"[DEBUG] Creating MediaItem for sticker {uid}: stickerset type={type(ss).__name__ if ss else None}"
                     )
                     logger.info(
-                        f"[DEBUG] StickerSet fields: short_name='{short_name}', name='{name}', title='{title}'"
+                        f"[DEBUG] StickerSet fields: short_name='{short_name}', name='{ss_name}', title='{title}'"
                     )
 
-                    sticker_set_name = short_name or name or title
+                    sticker_set_name = short_name or ss_name or title
                     mime = getattr(doc, "mime_type", None) or getattr(doc, "mime", None)
                     out.append(
                         MediaItem(

--- a/tests/test_media_format.py
+++ b/tests/test_media_format.py
@@ -85,6 +85,22 @@ def test_format_media_sentence_without_description():
     assert out == "[media] ‹the video that is not understood›"
 
 
+def test_format_media_sentence_animated_sticker():
+    out = format_media_sentence("animated_sticker", "A dancing cat with sparkles")
+    assert (
+        out
+        == "[media] ‹the animated_sticker that appears as A dancing cat with sparkles›"
+    )
+
+
+def test_format_media_sentence_video_with_description():
+    out = format_media_sentence("video", "A tutorial showing how to bake cookies")
+    assert (
+        out
+        == "[media] ‹the video that appears as A tutorial showing how to bake cookies›"
+    )
+
+
 @pytest.mark.parametrize("desc", ["", "   "])
 def test_format_media_sentence_not_understood(desc):
     out = format_media_sentence("audio", desc)

--- a/tests/test_media_format.py
+++ b/tests/test_media_format.py
@@ -3,9 +3,13 @@
 # Copyright (c) 2025 Cindy's World LLC and contributors
 # Licensed under the MIT License. See LICENSE.md for details.
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from media_format import (
+    _extract_sticker_set_name,
+    _format_sticker_sentence_internal,
     format_media_description,
     format_media_sentence,
     format_sticker_sentence,
@@ -45,8 +49,10 @@ def test_format_media_description_trims_whitespace():
     assert out == "that appears as hello"
 
 
-def test_format_sticker_sentence_with_desc():
-    out = format_sticker_sentence("😊", "HotCherry", "Kermit gives a thumbs up")
+def test_format_sticker_sentence_internal_with_desc():
+    out = _format_sticker_sentence_internal(
+        "😊", "HotCherry", "Kermit gives a thumbs up"
+    )
     assert (
         out
         == "[media] ‹the sticker `😊` from the sticker set `HotCherry` that appears as Kermit gives a thumbs up›"
@@ -54,8 +60,8 @@ def test_format_sticker_sentence_with_desc():
 
 
 @pytest.mark.parametrize("desc", ["", "   "])
-def test_format_sticker_sentence_without_desc(desc):
-    out = format_sticker_sentence("👋", "WendyDancer", desc)
+def test_format_sticker_sentence_internal_without_desc(desc):
+    out = _format_sticker_sentence_internal("👋", "WendyDancer", desc)
     assert (
         out
         == "[media] ‹the sticker `👋` from the sticker set `WendyDancer` that is not understood›"
@@ -65,8 +71,8 @@ def test_format_sticker_sentence_without_desc(desc):
 @pytest.mark.parametrize(
     "desc", ["not understood", "sticker not understood (format tgs)"]
 )
-def test_format_sticker_sentence_with_not_understood_text(desc):
-    out = format_sticker_sentence("👋", "WendyDancer", desc)
+def test_format_sticker_sentence_internal_with_not_understood_text(desc):
+    out = _format_sticker_sentence_internal("👋", "WendyDancer", desc)
     assert (
         out
         == f"[media] ‹the sticker `👋` from the sticker set `WendyDancer` that appears as {desc}›"
@@ -110,3 +116,194 @@ def test_format_media_sentence_not_understood(desc):
 def test_format_media_sentence_with_not_understood_text():
     out = format_media_sentence("audio", "not understood")
     assert out == "[media] ‹the audio that appears as not understood›"
+
+
+# Tests for the new async format_sticker_sentence function
+@pytest.mark.asyncio
+async def test_format_sticker_sentence_with_existing_attributes():
+    """Test format_sticker_sentence when MediaItem already has sticker info."""
+    # Create mock MediaItem with existing attributes
+    media_item = MagicMock()
+    media_item.unique_id = "test_123"
+    media_item.sticker_name = "😊"
+    media_item.sticker_set_name = "HotCherry"
+
+    # Mock dependencies
+    agent = MagicMock()
+    media_chain = AsyncMock()
+    media_chain.get.return_value = {"description": "Kermit gives a thumbs up"}
+    resolve_sticker_set_name = AsyncMock()
+
+    # Call the function
+    result = await format_sticker_sentence(
+        media_item, agent, media_chain, resolve_sticker_set_name
+    )
+
+    # Verify result
+    expected = "[media] ‹the sticker `😊` from the sticker set `HotCherry` that appears as Kermit gives a thumbs up›"
+    assert result == expected
+
+    # Verify media_chain.get was called
+    media_chain.get.assert_called_once_with("test_123", agent=agent)
+
+    # Verify resolve_sticker_set_name was NOT called (since we already have the name)
+    resolve_sticker_set_name.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_format_sticker_sentence_resolves_missing_set_name():
+    """Test format_sticker_sentence when it needs to resolve sticker set name."""
+    # Create mock MediaItem without sticker set name
+    media_item = MagicMock()
+    media_item.unique_id = "test_456"
+    media_item.sticker_name = "👋"
+    media_item.sticker_set_name = None
+
+    # Mock dependencies
+    agent = MagicMock()
+    media_chain = AsyncMock()
+    media_chain.get.return_value = {"description": "Waving hello"}
+    resolve_sticker_set_name = AsyncMock()
+    resolve_sticker_set_name.return_value = "WendyDancer"
+
+    # Call the function
+    result = await format_sticker_sentence(
+        media_item, agent, media_chain, resolve_sticker_set_name
+    )
+
+    # Verify result
+    expected = "[media] ‹the sticker `👋` from the sticker set `WendyDancer` that appears as Waving hello›"
+    assert result == expected
+
+    # Verify both functions were called
+    media_chain.get.assert_called_once_with("test_456", agent=agent)
+    resolve_sticker_set_name.assert_called_once_with(agent, media_item)
+
+
+@pytest.mark.asyncio
+async def test_format_sticker_sentence_fallback_behavior():
+    """Test format_sticker_sentence fallback when resolution fails."""
+    # Create mock MediaItem without any sticker info
+    media_item = MagicMock()
+    media_item.unique_id = "test_789"
+    media_item.sticker_name = None
+    media_item.sticker_set_name = None
+
+    # Mock dependencies
+    agent = MagicMock()
+    media_chain = AsyncMock()
+    media_chain.get.return_value = None  # No cached description
+    resolve_sticker_set_name = AsyncMock()
+    resolve_sticker_set_name.return_value = None  # Resolution fails
+
+    # Call the function
+    result = await format_sticker_sentence(
+        media_item, agent, media_chain, resolve_sticker_set_name
+    )
+
+    # Verify result with fallbacks
+    expected = "[media] ‹the sticker `(unnamed)` from the sticker set `(unknown)` that is not understood›"
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_format_sticker_sentence_handles_exceptions():
+    """Test format_sticker_sentence handles exceptions gracefully."""
+    # Create mock MediaItem
+    media_item = MagicMock()
+    media_item.unique_id = "test_error"
+    media_item.sticker_name = "🔥"
+    media_item.sticker_set_name = None
+
+    # Mock dependencies that raise exceptions
+    agent = MagicMock()
+    media_chain = AsyncMock()
+    media_chain.get.side_effect = Exception("Cache error")
+    resolve_sticker_set_name = AsyncMock()
+    resolve_sticker_set_name.side_effect = Exception("API error")
+
+    # Call the function
+    result = await format_sticker_sentence(
+        media_item, agent, media_chain, resolve_sticker_set_name
+    )
+
+    # Verify result with fallbacks (should still work despite exceptions)
+    expected = "[media] ‹the sticker `🔥` from the sticker set `(unknown)` that is not understood›"
+    assert result == expected
+
+
+# Tests for the comprehensive _extract_sticker_set_name function
+@pytest.mark.asyncio
+async def test_extract_sticker_set_name_from_media_item():
+    """Test extraction when MediaItem already has sticker set name."""
+    media_item = MagicMock()
+    media_item.unique_id = "test_123"
+    media_item.sticker_set_name = "HotCherry"
+
+    agent = MagicMock()
+    resolve_sticker_set_name = AsyncMock()
+
+    result = await _extract_sticker_set_name(
+        media_item, agent, resolve_sticker_set_name
+    )
+
+    assert result == "HotCherry"
+    # Should not call API since we already have the name
+    resolve_sticker_set_name.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_extract_sticker_set_name_via_api():
+    """Test extraction via API when MediaItem doesn't have set name."""
+    media_item = MagicMock()
+    media_item.unique_id = "test_456"
+    media_item.sticker_set_name = None
+
+    agent = MagicMock()
+    resolve_sticker_set_name = AsyncMock()
+    resolve_sticker_set_name.return_value = "WendyDancer"
+
+    result = await _extract_sticker_set_name(
+        media_item, agent, resolve_sticker_set_name
+    )
+
+    assert result == "WendyDancer"
+    resolve_sticker_set_name.assert_called_once_with(agent, media_item)
+
+
+@pytest.mark.asyncio
+async def test_extract_sticker_set_name_final_fallback():
+    """Test final fallback to (unknown) when API fails."""
+    media_item = MagicMock()
+    media_item.unique_id = "test_error"
+    media_item.sticker_set_name = None
+
+    agent = MagicMock()
+    resolve_sticker_set_name = AsyncMock()
+    resolve_sticker_set_name.return_value = None
+
+    result = await _extract_sticker_set_name(
+        media_item, agent, resolve_sticker_set_name
+    )
+
+    assert result == "(unknown)"
+    resolve_sticker_set_name.assert_called_once_with(agent, media_item)
+
+
+@pytest.mark.asyncio
+async def test_extract_sticker_set_name_api_exception():
+    """Test handling of API exceptions."""
+    media_item = MagicMock()
+    media_item.unique_id = "test_exception"
+    media_item.sticker_set_name = None
+
+    agent = MagicMock()
+    resolve_sticker_set_name = AsyncMock()
+    resolve_sticker_set_name.side_effect = Exception("API error")
+
+    result = await _extract_sticker_set_name(
+        media_item, agent, resolve_sticker_set_name
+    )
+
+    assert result == "(unknown)"
+    resolve_sticker_set_name.assert_called_once_with(agent, media_item)

--- a/tests/test_mime_utils.py
+++ b/tests/test_mime_utils.py
@@ -39,6 +39,12 @@ def test_get_file_extension_for_video_types():
     assert get_file_extension_for_mime_type("video/x-msvideo") == "avi"
 
 
+def test_get_file_extension_for_sticker_types():
+    """Test file extension mapping for sticker MIME types."""
+    assert get_file_extension_for_mime_type("application/gzip") == "tgs"
+    assert get_file_extension_for_mime_type("application/x-tgsticker") == "tgs"
+
+
 def test_is_video_mime_type():
     assert is_video_mime_type("video/mp4") is True
     assert is_video_mime_type("video/webm") is True

--- a/tests/test_mime_utils.py
+++ b/tests/test_mime_utils.py
@@ -1,0 +1,68 @@
+# tests/test_mime_utils.py
+
+# Copyright (c) 2025 Cindy's World LLC and contributors
+# Licensed under the MIT License. See LICENSE.md for details.
+
+import pytest
+
+from mime_utils import (
+    detect_mime_type_from_bytes,
+    get_file_extension_for_mime_type,
+    is_audio_mime_type,
+    is_image_mime_type,
+    is_video_mime_type,
+)
+
+
+def test_detect_video_formats():
+    # MP4 video signature
+    mp4_bytes = b"\x00\x00\x00\x20ftypmp41\x00\x00\x00\x00"
+    assert detect_mime_type_from_bytes(mp4_bytes) == "video/mp4"
+
+    # WebM video signature
+    webm_bytes = b"\x1a\x45\xdf\xa3\x93\x42\x82\x88"
+    assert detect_mime_type_from_bytes(webm_bytes) == "video/webm"
+
+    # QuickTime/MOV signature
+    mov_bytes = b"\x00\x00\x00\x14ftypqt  \x00\x00\x00\x00"
+    assert detect_mime_type_from_bytes(mov_bytes) == "video/quicktime"
+
+    # AVI signature
+    avi_bytes = b"RIFF\x00\x00\x00\x00AVI LIST"
+    assert detect_mime_type_from_bytes(avi_bytes) == "video/x-msvideo"
+
+
+def test_get_file_extension_for_video_types():
+    assert get_file_extension_for_mime_type("video/mp4") == "mp4"
+    assert get_file_extension_for_mime_type("video/webm") == "webm"
+    assert get_file_extension_for_mime_type("video/quicktime") == "mov"
+    assert get_file_extension_for_mime_type("video/x-msvideo") == "avi"
+
+
+def test_is_video_mime_type():
+    assert is_video_mime_type("video/mp4") is True
+    assert is_video_mime_type("video/webm") is True
+    assert is_video_mime_type("video/quicktime") is True
+    assert is_video_mime_type("video/x-msvideo") is True
+    assert is_video_mime_type("VIDEO/MP4") is True  # Case insensitive
+    assert is_video_mime_type("image/jpeg") is False
+    assert is_video_mime_type("audio/mp3") is False
+    assert is_video_mime_type("application/gzip") is False
+
+
+def test_is_image_mime_type():
+    assert is_image_mime_type("image/jpeg") is True
+    assert is_image_mime_type("image/png") is True
+    assert is_image_mime_type("image/webp") is True
+    assert is_image_mime_type("IMAGE/GIF") is True  # Case insensitive
+    assert is_image_mime_type("video/mp4") is False
+    assert is_image_mime_type("audio/mp3") is False
+
+
+def test_is_audio_mime_type():
+    assert is_audio_mime_type("audio/mpeg") is True
+    assert is_audio_mime_type("audio/ogg") is True
+    assert is_audio_mime_type("audio/flac") is True
+    assert is_audio_mime_type("AUDIO/WAV") is True  # Case insensitive
+    assert is_audio_mime_type("video/mp4") is False
+    assert is_audio_mime_type("image/jpeg") is False

--- a/tests/test_prompt_sticker_descriptions.py
+++ b/tests/test_prompt_sticker_descriptions.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from media_source import MediaSource
+from media_source import MediaSource, MediaStatus
 
 
 class FakeLLM:
@@ -50,7 +50,7 @@ async def test_prompt_includes_sticker_descriptions(monkeypatch):
             return {
                 "unique_id": unique_id,
                 "description": f"desc for {sticker_name}",
-                "status": "ok",
+                "status": MediaStatus.GENERATED.value,
             }
 
     fake_media_source = FakeMediaSource()

--- a/tests/test_telegram_media.py
+++ b/tests/test_telegram_media.py
@@ -87,3 +87,41 @@ def test_detect_gif_and_animation():
     msg_anim = make_msg(animation=anim)
     parts_anim = iter_media_parts(msg_anim)
     assert len(parts_anim) == 1 and parts_anim[0].kind == "animation"
+
+
+def test_detect_video_and_animated_sticker():
+    # Regular video via document mime type
+    video_doc = Obj(file_unique_id="vid_u5", mime_type="video/mp4")
+    msg_video = make_msg(document=video_doc)
+    parts_video = iter_media_parts(msg_video)
+    assert len(parts_video) == 1 and parts_video[0].kind == "video"
+    assert parts_video[0].unique_id == "vid_u5"
+    assert parts_video[0].mime == "video/mp4"
+
+    # WebM video
+    webm_doc = Obj(file_unique_id="webm_u6", mime_type="video/webm")
+    msg_webm = make_msg(document=webm_doc)
+    parts_webm = iter_media_parts(msg_webm)
+    assert len(parts_webm) == 1 and parts_webm[0].kind == "video"
+    assert parts_webm[0].mime == "video/webm"
+
+    # Animated sticker (TGS file) - gzip-compressed Lottie
+    tgs_doc = Obj(file_unique_id="tgs_u7", mime_type="application/gzip")
+    msg_tgs = make_msg(document=tgs_doc)
+    parts_tgs = iter_media_parts(msg_tgs)
+    assert len(parts_tgs) == 1 and parts_tgs[0].kind == "animated_sticker"
+    assert parts_tgs[0].unique_id == "tgs_u7"
+    assert parts_tgs[0].mime == "application/gzip"
+
+    # Video with DocumentAttributeVideo
+    attr_video = Obj()
+    attr_video.__class__.__name__ = "DocumentAttributeVideo"
+    video_attr_doc = Obj(
+        file_unique_id="vid_attr_u8",
+        mime_type="video/quicktime",
+        attributes=[attr_video],
+    )
+    msg_video_attr = make_msg(document=video_attr_doc)
+    parts_video_attr = iter_media_parts(msg_video_attr)
+    assert len(parts_video_attr) == 1 and parts_video_attr[0].kind == "video"
+    assert parts_video_attr[0].mime == "video/quicktime"


### PR DESCRIPTION
## Summary

This PR implements comprehensive video support for the media editor and fixes critical sticker name/set resolution bugs that were causing stickers to appear as "(unknown)" and "(unnamed)" in conversation history.

## Features Added

### 🎥 Video Support (Addresses #13)
- **Extended file format support**: Added `.mp4`, `.webm`, `.mov`, and `.avi` file extensions
- **Enhanced MIME type detection**: Added proper detection for QuickTime/MOV and AVI formats
- **Video file serving**: Added proper MIME type handling for video files in media editor
- **Media categorization**: Distinguish between animated stickers (TGS) and regular videos
- **Comprehensive testing**: Added tests for video detection, formatting, and MIME type handling

### 🐛 Sticker Resolution Bug Fixes
- **Fixed "(unknown)" sticker sets**: Resolved issue where sticker set names showed as "(unknown)"
- **Fixed "(unnamed)" stickers**: Resolved issue where sticker names showed as "(unnamed)"
- **Improved error handling**: Added comprehensive debugging and better fallback strategies
- **Duplicate call elimination**: Fixed duplicate `media_chain.get()` calls that overwrote resolved information

## Technical Changes

### Core Media System
- **`media_types.py`**: Added `video` and `animated_sticker` media kinds
- **`mime_utils.py`**: Enhanced MIME type detection for video formats (MP4, WebM, QuickTime, AVI)
- **`telegram_media.py`**: Updated media categorization logic to distinguish video types
- **`media_editor.py`**: Extended file serving and discovery to support video formats

### Bug Fixes
- **`media_injector.py`**: Fixed duplicate media chain calls that corrupted sticker information
- **Sticker name extraction**: Improved extraction from Telegram message attributes
- **Sticker set resolution**: Enhanced API-based resolution with better error handling
- **Metadata preservation**: Prevent error records from overwriting correctly resolved data

### Testing
- **New test file**: `test_mime_utils.py` with comprehensive MIME type testing
- **Enhanced existing tests**: Updated sticker detection and formatting tests
- **Video format tests**: Added tests for video file detection and handling

## Files Changed

### Core Implementation
- `src/media_types.py` - Added video media kinds
- `src/mime_utils.py` - Enhanced video MIME type detection
- `src/telegram_media.py` - Updated media categorization and debugging
- `src/media_editor.py` - Extended video file support
- `src/media_source.py` - Updated documentation

### Bug Fixes
- `src/media_injector.py` - Fixed sticker resolution and duplicate calls

### Testing
- `tests/test_telegram_media.py` - Added video and animated sticker tests
- `tests/test_media_format.py` - Added video formatting tests
- `tests/test_mime_utils.py` - New comprehensive MIME type tests

## Impact

### ✅ Video Support
- Media editor now supports common video formats (.mp4, .webm, .mov, .avi)
- Proper MIME type detection and file serving
- Distinction between animated stickers and regular videos
- Ready for future AI description integration

### ✅ Sticker Bug Fixes
- Eliminated "(unknown)" sticker set names in conversation history
- Eliminated "(unnamed)" sticker names in conversation history
- Improved debugging and error handling
- Better fallback strategies for unresolved stickers

## Testing

All tests pass successfully:
- 31 tests in media-related modules
- New video format detection tests
- Enhanced sticker resolution tests
- Comprehensive MIME type validation

## Backward Compatibility

- ✅ All existing functionality preserved
- ✅ No breaking changes to existing APIs
- ✅ Existing cached data remains compatible
- ✅ Graceful handling of unknown video formats

This PR successfully addresses issue #13 for video support while fixing critical sticker resolution bugs that were affecting conversation history quality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds full video format support, fixes sticker set/name resolution, and introduces an AIChain-based media pipeline with standardized statuses and improved caching.
> 
> - **Media Pipeline (core)**:
>   - **AI chaining & caching**: Introduces `AIChainMediaSource` orchestrating `UnsupportedFormat` → `BudgetExhausted` → `AIGeneratingMediaSource`, with smart retry and on-disk storage via `DirectoryMediaSource.put`.
>   - **Standardized statuses**: Adds `MediaStatus` enum and `_on_disk` flag; updates `make_error_record`, budget/unsupported paths to use it.
>   - **Refactors AI generation**: `AIGeneratingMediaSource` now returns records (no direct caching); chain handles persistence.
>   - **Default chain**: Rebuilt to use AI chain instead of direct generator.
> - **Sticker handling**:
>   - **Reliable set/name resolution**: New `_extract_sticker_set_name` and async `format_sticker_sentence(...)`; injector now resolves via API and avoids duplicate cache fetches.
>   - **Cleaner Telegram parsing**: Improves sticker attribute extraction in `telegram_media.py`.
> - **Video & animated media support**:
>   - **Kinds**: Adds `video` and `animated_sticker` to `MediaItem` and formatting.
>   - **MIME detection**: `mime_utils` detects `video/quicktime` (MOV) and `video/x-msvideo` (AVI); maps to `.mov`/`.avi`.
>   - **Editor support**: `media_editor.py` discovers/serves `.mp4`, `.webm`, `.mov`, `.avi` with correct MIME types; extended lookup across endpoints.
>   - **Media categorization**: Distinguishes TGS animated stickers vs regular videos in `telegram_media.py`.
> - **Diagnostics**:
>   - **Gemini debug**: Central `GEMINI_DEBUG_LOGGING` flag and richer response logging.
> - **Tests**:
>   - Adds `tests/test_mime_utils.py`; updates tests for `MediaStatus`, AI chaining, video/animated sticker detection, and new sticker formatting helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bf0ef8d0c79c07e7ed54e6f1963ea9e7252901d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->